### PR TITLE
feat: `validate_timestamp` implementation

### DIFF
--- a/src/validation.cairo
+++ b/src/validation.cairo
@@ -43,14 +43,10 @@ fn validate_target(self: @ChainState, block: @Block) -> Result<(), ByteArray> {
 }
 
 fn validate_timestamp(self: @ChainState, block: @Block) -> Result<(), ByteArray> {
-    let timestamp: u32 = *block.header.time;
-    let prev_timestamps = self.prev_timestamps;
-    let median_time = (*prev_timestamps).at((*prev_timestamps).len() - 6);
-
-    if timestamp > *median_time {
+    if block.header.time > (*self.prev_timestamps).at((*self.prev_timestamps).len() - 6) {
         Result::Ok(())
     } else {
-        Result::Err("Median time is greater than block's timestamp")
+        Result::Err("Median time is greater than or equal to block's timestamp")
     }
 }
 

--- a/src/validation.cairo
+++ b/src/validation.cairo
@@ -43,8 +43,15 @@ fn validate_target(self: @ChainState, block: @Block) -> Result<(), ByteArray> {
 }
 
 fn validate_timestamp(self: @ChainState, block: @Block) -> Result<(), ByteArray> {
-    // TODO: implement
-    Result::Ok(())
+    let timestamp: u32 = *block.header.time;
+    let prev_timestamps = self.prev_timestamps;
+    let median_time = (*prev_timestamps).at((*prev_timestamps).len() - 6);
+
+    if timestamp > *median_time {
+        Result::Ok(())
+    } else {
+        Result::Err("Median time is greater than block's timestamp")
+    }
 }
 
 fn next_prev_timestamps(self: @ChainState, block: @Block) -> Span<u32> {
@@ -69,11 +76,9 @@ fn validate_merkle_root(self: @ChainState, block: @Block) -> Result<(), ByteArra
 
 #[cfg(test)]
 mod tests {
-    use core::result::ResultTrait;
-    use super::validate_target;
+    use super::{validate_target, validate_timestamp};
     use super::{Block, ChainState};
     use super::super::state::{Header, Transaction, TxIn, TxOut};
-    use core::array::{Span};
 
     #[test]
     fn test_validate_target() {
@@ -104,5 +109,37 @@ mod tests {
         block.header.bits = 2;
         let result = validate_target(@chain_state, @block);
         assert(result.is_err(), 'Expected target to be invalid');
+    }
+
+    #[test]
+    fn test_validate_timestamp() {
+        let mut chain_state = ChainState {
+            block_height: 1,
+            total_work: 1,
+            best_block_hash: 1,
+            current_target: 1,
+            epoch_start_time: 1,
+            prev_timestamps: array![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].span(),
+        };
+        let mut block = Block {
+            header: Header {
+                version: 1, prev_block_hash: 1, merkle_root_hash: 1, time: 12, bits: 1, nonce: 1,
+            },
+            txs: ArrayTrait::new().span(),
+        };
+
+        // new timestamp is greater than the last timestamp
+        let result = validate_timestamp(@chain_state, @block);
+        assert(result.is_ok(), 'Expected target to be valid');
+
+        // new timestamp is strictly greater than the median of the last 11 timestamps
+        block.header.time = 7;
+        let result = validate_timestamp(@chain_state, @block);
+        assert(result.is_ok(), 'Expected target to be valid');
+
+        // new timestamp is equal to the median of the last 11 timestamps
+        block.header.time = 6;
+        let result = validate_timestamp(@chain_state, @block);
+        assert!(result.is_err(), "Median time is greater than block's timestamp");
     }
 }


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #21 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->

This PR implements `validate_timestamp` functions, which checks that the proposed timestamp for the new block is strictly greater than the median of the previous 11 timestamps.

My implementation is simplified compared to ZeroSync

ZeroSync uses cairo zero hints to retrieve the last 11 timestamps by reading 11 contiguous memory cells in the VM,  and then sorts the new array of 11 elements in order to find the median. I think this step can be skipped, it doesn't seem necessary to sort anything in our implementation as `prev_timestamps` in `ChainState` is necessary already sorted right?

also, what happens if `prev_timestamps` contains only a few values or even none (for example when syncing the very first blocks)? I'm assuming there are at least 6 values (11 - 5 = 6 to get the mean) , implementation will break if its not the case. But i guess for ZeroSync its the same? Trying to read 11 consecutives values in vm memory if there are less than 11 will fail with `reading unknow value` error
