### PR TITLE
[chore]: reorganize Tests crate

### DIFF
--- a/scripts/data/block_filter.jq
+++ b/scripts/data/block_filter.jq
@@ -6,8 +6,8 @@ def txin_coinbase:
             txid: 0_u256,
             vout: 0xffffffff_u32,
             txo_index: 0, // TODO: implement,
-            witness: @""
         },
+        witness: LITERAL_AT_QUOTES
     }"
 ;
 
@@ -20,6 +20,7 @@ def txin_regular:
             vout: \(.vout),
             txo_index: 0, // TODO: implement
         },
+        witness: LITERAL_AT_QUOTES
     }"
 ;
 
@@ -48,17 +49,16 @@ def tx:
     }"
 ;
 
-
 def block:
     "Block {
         header : Header {	
             version: \(.version)_u32,
             time: \(.time)_u32,
-            bits: 0, # TODO
+            bits: 0, // TODO
             nonce: \(.nonce)_u32
         },
 		txs: array![\(.tx | map(tx) | join(",\n"))].span()
-   };"
+   }"
 ;
 
 def fixture:
@@ -69,6 +69,7 @@ pub fn block_\(.height)() -> Block {
     // block hash: \(.hash)
      \( . | block )
 }"
+;
 
 .result | fixture
 

--- a/scripts/data/block_filter.jq
+++ b/scripts/data/block_filter.jq
@@ -13,7 +13,7 @@ def txin_coinbase:
 
 def txin_regular:
     "TxIn {
-        script: from_base16(\@"\(.scriptSig.hex)\"),
+        script: from_base16(\"\(.scriptSig.hex)\"),
         sequence: \(.sequence),
         previous_output: OutPoint {
             txid: 0x\(.txid),
@@ -34,7 +34,7 @@ def txin:
 def txout:
     "TxOut {
         value: \(.value*100000000)_u64,
-        pk_script: from_base16(\@"\(.scriptPubKey.hex)\"),
+        pk_script: from_base16(\"\(.scriptPubKey.hex)\"),
     }"
 ;
 

--- a/scripts/data/block_filter.jq
+++ b/scripts/data/block_filter.jq
@@ -5,7 +5,7 @@ def txin_coinbase:
         previous_output: OutPoint {
             txid: 0_u256,
             vout: 0xffffffff_u32,
-            txo_index: 0, // TODO: implement,
+            txo_index: 0, // TODO: implement
         },
         witness: LITERAL_AT_QUOTES
     }"

--- a/scripts/data/block_filter.jq
+++ b/scripts/data/block_filter.jq
@@ -54,7 +54,7 @@ def block:
         header : Header {	
             version: \(.version)_u32,
             time: \(.time)_u32,
-            bits: 0,
+            bits: 0, # TODO
             nonce: \(.nonce)_u32
         },
 		txs: array![\(.tx | map(tx) | join(",\n"))].span()

--- a/scripts/data/block_filter.jq
+++ b/scripts/data/block_filter.jq
@@ -5,14 +5,15 @@ def txin_coinbase:
         previous_output: OutPoint {
             txid: 0_u256,
             vout: 0xffffffff_u32,
-            txo_index: 0, // TODO: implement
+            txo_index: 0, // TODO: implement,
+            witness: @""
         },
     }"
 ;
 
 def txin_regular:
     "TxIn {
-        script: from_base16(\"\(.scriptSig.hex)\"),
+        script: from_base16(\@"\(.scriptSig.hex)\"),
         sequence: \(.sequence),
         previous_output: OutPoint {
             txid: 0x\(.txid),
@@ -33,7 +34,7 @@ def txin:
 def txout:
     "TxOut {
         value: \(.value*100000000)_u64,
-        pk_script: from_base16(\"\(.scriptPubKey.hex)\"),
+        pk_script: from_base16(\@"\(.scriptPubKey.hex)\"),
     }"
 ;
 
@@ -53,6 +54,7 @@ def block:
         header : Header {	
             version: \(.version)_u32,
             time: \(.time)_u32,
+            bits: 0,
             nonce: \(.nonce)_u32
         },
 		txs: array![\(.tx | map(tx) | join(",\n"))].span()
@@ -60,13 +62,13 @@ def block:
 ;
 
 def fixture:
-"use super::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
+"use raito::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
+use super::super::utils::from_base16;
 
 pub fn block_\(.height)() -> Block {
     // block hash: \(.hash)
      \( . | block )
 }"
-;
 
 .result | fixture
 

--- a/scripts/data/get_block.sh
+++ b/scripts/data/get_block.sh
@@ -15,6 +15,3 @@ curl \
     }' \
  -H 'content-type: text/plain;' $BITCOIN_RPC \
  | jq -r -f scripts/data/block_filter.jq | sed 's/LITERAL_AT_QUOTES/@""/g' > tests/blocks/block_${HEIGHT}.cairo
-
-      # validate_target, validate_timestamp, validate_proof_of_work, compute_block_reward,
-      # compute_total_work,

--- a/scripts/data/get_block.sh
+++ b/scripts/data/get_block.sh
@@ -14,4 +14,7 @@ curl \
     "params": ["'${1}'", 2]
     }' \
  -H 'content-type: text/plain;' $BITCOIN_RPC \
- | jq -r -f scripts/data/block_filter.jq > tests/blocks/block_${HEIGHT}.cairo
+ | jq -r -f scripts/data/block_filter.jq | sed 's/LITERAL_AT_QUOTES/@""/g' > tests/blocks/block_${HEIGHT}.cairo
+
+      # validate_target, validate_timestamp, validate_proof_of_work, compute_block_reward,
+      # compute_total_work,

--- a/scripts/data/get_block.sh
+++ b/scripts/data/get_block.sh
@@ -15,6 +15,3 @@ curl \
     }' \
  -H 'content-type: text/plain;' $BITCOIN_RPC \
  | jq -r -f scripts/data/block_filter.jq > tests/blocks/block_${HEIGHT}.cairo
-
-        validate_target, validate_timestamp, validate_proof_of_work, compute_block_reward,
-         compute_total_work,

--- a/scripts/data/get_blocks.sh
+++ b/scripts/data/get_blocks.sh
@@ -10,7 +10,7 @@ get_single_block() {
 main() {
     local block_hashes=(
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"  # Genesis block
-        "00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee"  # Block 170
+        "00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee"  # Block containing first P2P tx to Hal Finney
     )
 
     # Loop through the block hashes and call get_block.sh for each

--- a/scripts/data/get_blocks.sh
+++ b/scripts/data/get_blocks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e;
+set -o pipefail;
+
+get_single_block() {
+    local block_hash=$1
+    ./scripts/data/get_block.sh "$block_hash"
+}
+
+main() {
+    local block_hashes=(
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"  # Genesis block
+        "00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee"  # Block 170
+    )
+
+    # Loop through the block hashes and call get_block.sh for each
+    for block_hash in "${block_hashes[@]}"; do
+        echo "Getting block: $block_hash"
+        get_single_block "$block_hash"
+    done
+
+    echo "All blocks retrieved successfully."
+}
+
+main

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,6 +1,6 @@
 pub mod utils;
 pub mod validation;
+pub mod state;
 
-mod state;
 mod main;
 mod merkle_tree;

--- a/src/state.cairo
+++ b/src/state.cairo
@@ -108,7 +108,7 @@ pub struct Transaction {
 #[derive(Drop, Copy)]
 pub struct TxOut {
     /// The value of the output in satoshis.
-    pub value: i64,
+    pub value: u64,
     /// The spending script (aka locking code) for this output.
     pub pk_script: @ByteArray,
 }
@@ -127,7 +127,7 @@ pub struct TxIn {
     /// The reference to the previous output that is being used as an input.
     pub previous_output: OutPoint,
     /// The witness data for transactions.
-    pub witness: Span<ByteArray>,
+    pub witness: @ByteArray
 }
 
 

--- a/tests/blocks.cairo
+++ b/tests/blocks.cairo
@@ -1,0 +1,2 @@
+mod block_0;
+mod block_170;

--- a/tests/blocks/block_0.cairo
+++ b/tests/blocks/block_0.cairo
@@ -5,9 +5,11 @@ use super::super::utils::from_base16;
 
 pub fn block_0() -> Block {
     // block hash: 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-
     Block {
-        header: Header { version: 1_u32, time: 1231006505_u32, bits: 0, nonce: 2083236893_u32 },
+        header: Header {
+            version: 1_u32, time: 1231006505_u32, bits: 0, // TODO
+             nonce: 2083236893_u32
+        },
         txs: array![
             Transaction {
                 version: 1,
@@ -19,9 +21,9 @@ pub fn block_0() -> Block {
                         ),
                         sequence: 4294967295,
                         previous_output: OutPoint {
-                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
+                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement,
                         },
-                        witness: @"",
+                        witness: @""
                     }
                 ]
                     .span(),

--- a/tests/blocks/block_0.cairo
+++ b/tests/blocks/block_0.cairo
@@ -1,8 +1,6 @@
 use raito::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
 use super::super::utils::from_base16;
 
-// genesis block
-
 pub fn block_0() -> Block {
     // block hash: 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
     Block {
@@ -21,7 +19,7 @@ pub fn block_0() -> Block {
                         ),
                         sequence: 4294967295,
                         previous_output: OutPoint {
-                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement,
+                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
                         },
                         witness: @""
                     }

--- a/tests/blocks/block_0.cairo
+++ b/tests/blocks/block_0.cairo
@@ -15,7 +15,7 @@ pub fn block_0() -> Block {
                 inputs: array![
                     TxIn {
                         script: from_base16(
-                            @"04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"
+                            "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"
                         ),
                         sequence: 4294967295,
                         previous_output: OutPoint {
@@ -29,7 +29,7 @@ pub fn block_0() -> Block {
                     TxOut {
                         value: 5000000000_u64,
                         pk_script: from_base16(
-                            @"4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
+                            "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
                         ),
                     }
                 ]

--- a/tests/blocks/block_0.cairo
+++ b/tests/blocks/block_0.cairo
@@ -1,9 +1,13 @@
-use super::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
+use raito::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
+use super::super::utils::from_base16;
+
+// genesis block
 
 pub fn block_0() -> Block {
     // block hash: 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+
     Block {
-        header: Header { version: 1_u32, time: 1231006505_u32, nonce: 2083236893_u32 },
+        header: Header { version: 1_u32, time: 1231006505_u32, bits: 0, nonce: 2083236893_u32 },
         txs: array![
             Transaction {
                 version: 1,
@@ -11,12 +15,13 @@ pub fn block_0() -> Block {
                 inputs: array![
                     TxIn {
                         script: from_base16(
-                            "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"
+                            @"04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"
                         ),
                         sequence: 4294967295,
                         previous_output: OutPoint {
                             txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
                         },
+                        witness: @"",
                     }
                 ]
                     .span(),
@@ -24,7 +29,7 @@ pub fn block_0() -> Block {
                     TxOut {
                         value: 5000000000_u64,
                         pk_script: from_base16(
-                            "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
+                            @"4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
                         ),
                     }
                 ]
@@ -33,5 +38,5 @@ pub fn block_0() -> Block {
             }
         ]
             .span()
-    };
+    }
 }

--- a/tests/blocks/block_170.cairo
+++ b/tests/blocks/block_170.cairo
@@ -1,8 +1,6 @@
 use raito::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
 use super::super::utils::from_base16;
 
-// // block containing first P2P tx to Hal Finney
-
 pub fn block_170() -> Block {
     // block hash: 00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee
     Block {
@@ -19,7 +17,7 @@ pub fn block_170() -> Block {
                         script: from_base16("04ffff001d0102"),
                         sequence: 4294967295,
                         previous_output: OutPoint {
-                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement,
+                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
                         },
                         witness: @""
                     }

--- a/tests/blocks/block_170.cairo
+++ b/tests/blocks/block_170.cairo
@@ -1,12 +1,15 @@
 use raito::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
 use super::super::utils::from_base16;
 
-// block containing first P2P tx to Hal Finney
+// // block containing first P2P tx to Hal Finney
 
 pub fn block_170() -> Block {
     // block hash: 00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee
     Block {
-        header: Header { version: 1_u32, time: 1231731025_u32, bits: 0, nonce: 1889418792_u32 },
+        header: Header {
+            version: 1_u32, time: 1231731025_u32, bits: 0, // TODO
+             nonce: 1889418792_u32
+        },
         txs: array![
             Transaction {
                 version: 1,
@@ -16,7 +19,7 @@ pub fn block_170() -> Block {
                         script: from_base16("04ffff001d0102"),
                         sequence: 4294967295,
                         previous_output: OutPoint {
-                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
+                            txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement,
                         },
                         witness: @""
                     }

--- a/tests/blocks/block_170.cairo
+++ b/tests/blocks/block_170.cairo
@@ -13,7 +13,7 @@ pub fn block_170() -> Block {
                 is_segwit: false,
                 inputs: array![
                     TxIn {
-                        script: from_base16(@"04ffff001d0102"),
+                        script: from_base16("04ffff001d0102"),
                         sequence: 4294967295,
                         previous_output: OutPoint {
                             txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
@@ -26,7 +26,7 @@ pub fn block_170() -> Block {
                     TxOut {
                         value: 5000000000_u64,
                         pk_script: from_base16(
-                            @"4104d46c4968bde02899d2aa0963367c7a6ce34eec332b32e42e5f3407e052d64ac625da6f0718e7b302140434bd725706957c092db53805b821a85b23a7ac61725bac"
+                            "4104d46c4968bde02899d2aa0963367c7a6ce34eec332b32e42e5f3407e052d64ac625da6f0718e7b302140434bd725706957c092db53805b821a85b23a7ac61725bac"
                         ),
                     }
                 ]
@@ -39,7 +39,7 @@ pub fn block_170() -> Block {
                 inputs: array![
                     TxIn {
                         script: from_base16(
-                            @"47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
+                            "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
                         ),
                         sequence: 4294967295,
                         previous_output: OutPoint {
@@ -55,13 +55,13 @@ pub fn block_170() -> Block {
                     TxOut {
                         value: 1000000000_u64,
                         pk_script: from_base16(
-                            @"4104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac"
+                            "4104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac"
                         ),
                     },
                     TxOut {
                         value: 4000000000_u64,
                         pk_script: from_base16(
-                            @"410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac"
+                            "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac"
                         ),
                     }
                 ]

--- a/tests/blocks/block_170.cairo
+++ b/tests/blocks/block_170.cairo
@@ -1,20 +1,24 @@
-use super::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
+use raito::state::{Block, Header, Transaction, OutPoint, TxIn, TxOut};
+use super::super::utils::from_base16;
+
+// block containing first P2P tx to Hal Finney
 
 pub fn block_170() -> Block {
     // block hash: 00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee
     Block {
-        header: Header { version: 1_u32, time: 1231731025_u32, nonce: 1889418792_u32 },
+        header: Header { version: 1_u32, time: 1231731025_u32, bits: 0, nonce: 1889418792_u32 },
         txs: array![
             Transaction {
                 version: 1,
                 is_segwit: false,
                 inputs: array![
                     TxIn {
-                        script: from_base16("04ffff001d0102"),
+                        script: from_base16(@"04ffff001d0102"),
                         sequence: 4294967295,
                         previous_output: OutPoint {
                             txid: 0_u256, vout: 0xffffffff_u32, txo_index: 0, // TODO: implement
                         },
+                        witness: @""
                     }
                 ]
                     .span(),
@@ -22,7 +26,7 @@ pub fn block_170() -> Block {
                     TxOut {
                         value: 5000000000_u64,
                         pk_script: from_base16(
-                            "4104d46c4968bde02899d2aa0963367c7a6ce34eec332b32e42e5f3407e052d64ac625da6f0718e7b302140434bd725706957c092db53805b821a85b23a7ac61725bac"
+                            @"4104d46c4968bde02899d2aa0963367c7a6ce34eec332b32e42e5f3407e052d64ac625da6f0718e7b302140434bd725706957c092db53805b821a85b23a7ac61725bac"
                         ),
                     }
                 ]
@@ -35,7 +39,7 @@ pub fn block_170() -> Block {
                 inputs: array![
                     TxIn {
                         script: from_base16(
-                            "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
+                            @"47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
                         ),
                         sequence: 4294967295,
                         previous_output: OutPoint {
@@ -43,6 +47,7 @@ pub fn block_170() -> Block {
                             vout: 0,
                             txo_index: 0, // TODO: implement
                         },
+                        witness: @""
                     }
                 ]
                     .span(),
@@ -50,13 +55,13 @@ pub fn block_170() -> Block {
                     TxOut {
                         value: 1000000000_u64,
                         pk_script: from_base16(
-                            "4104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac"
+                            @"4104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac"
                         ),
                     },
                     TxOut {
                         value: 4000000000_u64,
                         pk_script: from_base16(
-                            "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac"
+                            @"410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac"
                         ),
                     }
                 ]
@@ -65,5 +70,5 @@ pub fn block_170() -> Block {
             }
         ]
             .span()
-    };
+    }
 }

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -1,0 +1,3 @@
+mod tests;
+mod utils;
+mod blocks;

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -10,7 +10,7 @@ fn hex_to_byte(h: u8) -> u8 {
     0
 }
 
-pub fn from_base16(hexs: @ByteArray) -> ByteArray {
+pub fn from_base16(hexs: @ByteArray) -> @ByteArray {
     let mut result: ByteArray = Default::default();
     let mut i = 0;
     let len = hexs.len();
@@ -18,5 +18,6 @@ pub fn from_base16(hexs: @ByteArray) -> ByteArray {
         result.append_word(hex_to_byte(hexs.at(i).unwrap()).into(), 4);
         i += 1;
     };
-    result
+
+    @result
 }

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -10,7 +10,7 @@ fn hex_to_byte(h: u8) -> u8 {
     0
 }
 
-pub fn from_base16(hexs: @ByteArray) -> @ByteArray {
+pub fn from_base16(hexs: ByteArray) -> @ByteArray {
     let mut result: ByteArray = Default::default();
     let mut i = 0;
     let len = hexs.len();


### PR DESCRIPTION
This PR reorganizes Tests crate because all files inside it except tests.cairo where not compiled when running `scarb test`.

Now everything compiles, but the scripts to generate will still need improvements