### PR TITLE
[bug] fee sub overflow calculation

### DIFF
--- a/src/validation.cairo
+++ b/src/validation.cairo
@@ -211,11 +211,13 @@ fn fee_and_merkle_root(block: @Block) -> Result<(u64, Hash), ByteArray> {
     let mut total_fee = 0;
 
     // skipping the coinbase transaction
-    let mut i = 1;
+    let mut i = 0;
     while (i < (*block).txs.len()) {
         let tx = block.txs[i];
         txids.append(tx.txid().into());
-        total_fee += tx.fee();
+        if (i != 0) {
+            total_fee += tx.fee();
+        }
         i += 1;
     };
 

--- a/src/validation.cairo
+++ b/src/validation.cairo
@@ -210,11 +210,11 @@ fn fee_and_merkle_root(block: @Block) -> Result<(u64, Hash), ByteArray> {
     let mut txids: Array<Hash> = array![];
     let mut total_fee = 0;
 
-    // skipping the coinbase transaction
     let mut i = 0;
-    while (i < (*block).txs.len()) {
+    while (i < (*block.txs).len()) {
         let tx = block.txs[i];
-        txids.append(tx.txid().into());
+        txids.append(tx.txid());
+        // skipping the coinbase transaction
         if (i != 0) {
             total_fee += tx.fee();
         }

--- a/src/validation.cairo
+++ b/src/validation.cairo
@@ -210,9 +210,13 @@ fn fee_and_merkle_root(block: @Block) -> Result<(u64, Hash), ByteArray> {
     let mut txids: Array<Hash> = array![];
     let mut total_fee = 0;
 
-    for tx in *block.txs {
+    // skipping the coinbase transaction
+    let mut i = 1;
+    while (i < (*block).txs.len()) {
+        let tx = block.txs[i];
         txids.append(tx.txid().into());
         total_fee += tx.fee();
+        i += 1;
     };
 
     Result::Ok((total_fee, merkle_root(ref txids)))


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #74 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->
I've kept the fee calculation function intact since its scope is the transaction, but in the fee_and_merkle_root function, I've skipped the first transaction.