### PR TITLE
Additional helpers for calculating double sha256 digest

### DIFF
--- a/src/merkle_tree.cairo
+++ b/src/merkle_tree.cairo
@@ -1,4 +1,4 @@
-use super::utils::{double_sha256, Hash};
+use super::utils::{double_sha256_parent, Hash};
 
 pub fn merkle_root(ref hashes: Array<Hash>) -> Hash {
     let len = hashes.len();
@@ -17,7 +17,7 @@ pub fn merkle_root(ref hashes: Array<Hash>) -> Hash {
     let mut next_hashes: Array<Hash> = array![];
     let mut i = 0;
     while i < len {
-        next_hashes.append(double_sha256(hashes[i], hashes[i + 1]));
+        next_hashes.append(double_sha256_parent(hashes[i], hashes[i + 1]));
         i += 2;
     };
 

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -235,7 +235,7 @@ pub fn double_sha256_byte_array(bytes: @ByteArray) -> Hash {
 
 /// Calculate double sha256 digest of an array of full 4 byte words
 ///
-/// It's imporant that there are no trailing bytes, otherwise the
+/// It's important that there are no trailing bytes, otherwise the
 /// data will be truncated.
 pub fn double_sha256_u32_array(words: Array<u32>) -> Hash {
     let mut input2: Array<u32> = array![];

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -32,6 +32,16 @@ impl HashPartialEq of PartialEq<Hash> {
     }
 }
 
+pub impl HashIntoByteArray of Into<Hash, ByteArray> {
+    fn into(self: Hash) -> ByteArray {
+        let mut bytes: ByteArray = Default::default();
+        for word in self.value.span() {
+            bytes.append_word((*word).into(), 4);
+        };
+        bytes
+    }
+}
+
 pub impl U256IntoHash of Into<u256, Hash> {
     fn into(self: u256) -> Hash {
         let mut result: Array<u32> = array![];
@@ -203,7 +213,8 @@ pub fn fast_pow<
     }
 }
 
-pub fn double_sha256(a: @Hash, b: @Hash) -> Hash {
+/// Calculate double sha256 digest of a concatenation of two hashes
+pub fn double_sha256_parent(a: @Hash, b: @Hash) -> Hash {
     let mut input1: Array<u32> = array![];
     input1.append_span(a.value.span());
     input1.append_span(b.value.span());
@@ -212,4 +223,57 @@ pub fn double_sha256(a: @Hash, b: @Hash) -> Hash {
     input2.append_span(compute_sha256_u32_array(input1, 0, 0).span());
 
     HashTrait::to_hash(compute_sha256_u32_array(input2, 0, 0))
+}
+
+/// Calculate double sha256 digest of bytes
+pub fn double_sha256_byte_array(bytes: @ByteArray) -> Hash {
+    let mut input2: Array<u32> = array![];
+    input2.append_span(compute_sha256_byte_array(bytes).span());
+
+    HashTrait::to_hash(compute_sha256_u32_array(input2, 0, 0))
+}
+
+/// Calculate double sha256 digest of an array of full 4 byte words
+///
+/// It's imporant that there are no trailing bytes, otherwise the
+/// data will be truncated.
+pub fn double_sha256_u32_array(words: Array<u32>) -> Hash {
+    let mut input2: Array<u32> = array![];
+    input2.append_span(compute_sha256_u32_array(words, 0, 0).span());
+
+    HashTrait::to_hash(compute_sha256_u32_array(input2, 0, 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{double_sha256_byte_array, double_sha256_u32_array, double_sha256_parent, Hash};
+    use super::super::test_utils::from_hex;
+
+    #[test]
+    fn test_double_sha256_byte_array() {
+        // hashlib.sha256(sha256(b"bitcoin").digest()).hexdigest()
+        assert_eq!(
+            double_sha256_byte_array(@"bitcoin").into(),
+            from_hex("f1ef1bf105d788352c052453b15a913403be59b90ddf9f7c1f937edee8938dc5")
+        )
+    }
+
+    #[test]
+    fn test_double_sha256_u32_array() {
+        // hashlib.sha256(sha256(bytes.fromhex("00000001000000020000000300000004000000050000000600000007")).digest()).hexdigest()
+        assert_eq!(
+            double_sha256_u32_array(array![1, 2, 3, 4, 5, 6, 7]).into(),
+            from_hex("489b8eeb4024cb77ab057616ebf7f8d4405aa0bd3ad5f42e6b4c20580e011ac4")
+        )
+    }
+
+    #[test]
+    fn test_double_sha256_parent() {
+        // hashlib.sha256(sha256(bytes.fromhex("00000001" * 8 + "00000002" *
+        // 8)).digest()).hexdigest()
+        assert_eq!(
+            double_sha256_parent(@Hash { value: [1; 8] }, @Hash { value: [2; 8] }).into(),
+            from_hex("14a6e4a4caef969126944266724d11866b39b3390cee070b0aa4c9390cd77f47")
+        )
+    }
 }


### PR DESCRIPTION
**What**

This PR adds two more helpers for calculating double sha256 for array of bytes and u32 respectively.

**Why**

There are currently three cases when we need to calculate double sha256:
- For Merkle tree construction (parent of two hashes)
- For block header (which can be respresented as u32 array)
- For transactions (which are variable size hence can only be represented as bytes)

