### PR TITLE
update genesis chain_state

### DIFF
--- a/scripts/data/get_blocks.sh
+++ b/scripts/data/get_blocks.sh
@@ -14,7 +14,6 @@ get_single_block() {
 
 main() {
     local block_hashes=(
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"  # Genesis block (0)
         "00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee"  # Block containing first P2P tx to Hal Finney (170)
         "00000000132fbe8314fc571c0be60b31ccd461c9ee85f42bde8c6d160a9dacc0"  # Bloc containing first off ramp tx from Martti Malmi (24835)
         "00000000152340ca42227603908689183edc47355204e7aca59383b0aaac1fd8"  # Block containing pizza tx (57043)

--- a/scripts/data/light_client_args_170.json
+++ b/scripts/data/light_client_args_170.json
@@ -1,9 +1,6 @@
 {
     "chain_state": {
-        "block_height": {
-            "some": 0,
-            "value": 169
-        },
+        "block_height": 169,
         "total_work": "730155581610",
         "best_block_hash": "0x000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55",
         "current_target": "26959535291011309493156476344723991336010898738574164086137773096960",

--- a/src/types/chain_state.cairo
+++ b/src/types/chain_state.cairo
@@ -8,8 +8,7 @@ use crate::utils::hash::Hash;
 use crate::validation::{
     difficulty::{validate_bits, adjust_difficulty}, coinbase::validate_coinbase,
     timestamp::{validate_timestamp, next_prev_timestamps},
-    work::{validate_proof_of_work, compute_total_work},
-    block::{next_block_height, fee_and_merkle_roots},
+    work::{validate_proof_of_work, compute_total_work}, block::{fee_and_merkle_roots},
 };
 use super::block::{BlockHash, Block, TransactionData};
 
@@ -17,7 +16,7 @@ use super::block::{BlockHash, Block, TransactionData};
 #[derive(Drop, Copy, Debug, PartialEq)]
 pub struct ChainState {
     /// Height of the current block.
-    pub block_height: Option<u32>,
+    pub block_height: u32,
     /// Total work done.
     pub total_work: u256,
     /// Best block.
@@ -34,21 +33,19 @@ pub struct ChainState {
     pub prev_timestamps: Span<u32>,
 }
 
-/// Represents the initial state before genesis block.
+/// Represents the initial state after genesis block.
 /// https://github.com/bitcoin/bitcoin/blob/ee367170cb2acf82b6ff8e0ccdbc1cce09730662/src/kernel/chainparams.cpp#L99
-///
-/// TODO: use the chain state AFTER genesis block instead, that would make the block validation
-/// simpler since we no longer need to handle special genesis case.
 impl ChainStateDefault of Default<ChainState> {
     fn default() -> ChainState {
         ChainState {
-            block_height: Default::default(),
-            total_work: 0,
-            best_block_hash: 0_u256.into(),
-            current_target: 26959535291011309493156476344723991336010898738574164086137773096960,
+            block_height: 0,
+            total_work: 4295032833,
+            best_block_hash: 0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f_u256
+                .into(),
+            current_target: 0x00000000ffff0000000000000000000000000000000000000000000000000000_u256,
             epoch_start_time: 1231006505,
             prev_timestamps: [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1231006505
             ].span(),
         }
     }
@@ -58,7 +55,7 @@ impl ChainStateDefault of Default<ChainState> {
 #[generate_trait]
 pub impl BlockValidatorImpl of BlockValidator {
     fn validate_and_apply(self: ChainState, block: Block) -> Result<ChainState, ByteArray> {
-        let block_height = next_block_height(self.block_height);
+        let block_height = self.block_height + 1;
 
         validate_timestamp(self.prev_timestamps, block.header.time)?;
         let prev_block_time = *self.prev_timestamps[self.prev_timestamps.len() - 1];
@@ -90,7 +87,7 @@ pub impl BlockValidatorImpl of BlockValidator {
 
         Result::Ok(
             ChainState {
-                block_height: Option::Some(block_height),
+                block_height,
                 total_work,
                 best_block_hash,
                 current_target,

--- a/src/validation/block.cairo
+++ b/src/validation/block.cairo
@@ -4,15 +4,6 @@ use crate::types::transaction::{Transaction, TransactionTrait};
 use crate::utils::{hash::Hash, merkle_tree::merkle_root};
 use super::transaction::validate_transaction;
 
-/// Returns the next block height
-/// If the block height is None (Genesis block), it returns 0
-pub fn next_block_height(block_height: Option<u32>) -> u32 {
-    match block_height {
-        Option::Some(height) => height + 1,
-        Option::None => 0,
-    }
-}
-
 /// Validates transactions and aggregates:
 ///  - Total fee
 ///  - TXID merkle root

--- a/tests/light_client/block_170.cairo
+++ b/tests/light_client/block_170.cairo
@@ -6,7 +6,7 @@ use raito::types::block::{Block, Header, TransactionData};
 /// Chain state at the beginning of the test
 fn chain_state_169() -> ChainState {
     ChainState {
-        block_height: Option::Some(169),
+        block_height: 169,
         total_work: 730155581610_u256,
         best_block_hash: 0x000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55_u256
             .into(),
@@ -43,7 +43,7 @@ fn block_170() -> Block {
 /// Expected chain state at the end of the test
 fn chain_state_170() -> ChainState {
     ChainState {
-        block_height: Option::Some(170),
+        block_height: 170,
         total_work: 734450614443_u256,
         best_block_hash: 0x00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee_u256
             .into(),

--- a/tests/tests.cairo
+++ b/tests/tests.cairo
@@ -1,24 +1,71 @@
-use raito::types::chain_state::{ChainState, BlockValidator};
-use super::blocks::{block_0::block_0, block_170::block_170};
+use raito::utils::hex::from_hex;
+use raito::types::{
+    chain_state::{ChainState, BlockValidator}, block::{Block, Header, TransactionData},
+    transaction::{Transaction, TxIn, TxOut, OutPoint},
+};
+use super::blocks::{block_170::block_170};
 
 #[test]
-fn test_block0() {
-    let block = block_0();
+fn test_block1() {
+    let block = Block {
+        header: Header {
+            version: 1_u32, time: 1231469665_u32, bits: 486604799_u32, nonce: 2573394689_u32,
+        },
+        data: TransactionData::Transactions(
+            array![
+                Transaction {
+                    version: 1,
+                    is_segwit: false,
+                    lock_time: 0,
+                    inputs: array![
+                        TxIn {
+                            script: @from_hex("04ffff001d0104"),
+                            sequence: 0xffffffff,
+                            witness: array![].span(),
+                            previous_output: OutPoint {
+                                txid: 0_u256.into(),
+                                vout: 4294967295_u32,
+                                data: Default::default(),
+                                block_height: Default::default(),
+                                block_time: Default::default(),
+                            },
+                        }
+                    ]
+                        .span(),
+                    outputs: array![
+                        TxOut {
+                            value: 5000000000_u64,
+                            pk_script: @from_hex(
+                                "410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac"
+                            ),
+                            cached: false,
+                        },
+                    ]
+                        .span(),
+                },
+            ]
+                .span()
+        )
+    };
     let prev_chain_state: ChainState = Default::default();
 
     let next_chain_state = prev_chain_state.validate_and_apply(block);
     assert!(next_chain_state.is_ok(), "Error: {:?}", next_chain_state.err());
 
     let result = next_chain_state.unwrap();
-    assert_eq!(result.block_height.unwrap(), 0);
-    assert_eq!(result.total_work, 4295032833);
-    assert_eq!(result.prev_timestamps, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1231006505].span());
+    assert_eq!(result.block_height, 1);
+    assert_eq!(result.total_work, 8590065666);
+    assert_eq!(result.prev_timestamps, [0, 0, 0, 0, 0, 0, 0, 0, 0, 1231006505, 1231469665].span());
     assert_eq!(
-        result.current_target, 0x00000000ffff0000000000000000000000000000000000000000000000000000
+        result.current_target,
+        0x00000000ffff0000000000000000000000000000000000000000000000000000_u256
     );
     assert_eq!(result.epoch_start_time, 1231006505);
+    assert_eq!(
+        result.best_block_hash,
+        0x00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048_u256.into()
+    );
     //to impl
-// assert_eq!(result.best_block_hash, 0_u256.into());
 // assert_eq!(result.utreexo_state.roots, [...]);
 
 }
@@ -27,7 +74,7 @@ fn test_block0() {
 fn test_block170() {
     let block170 = block_170();
     let prev_chain_state_block169 = ChainState {
-        block_height: Option::Some(169),
+        block_height: 169,
         total_work: 734450614443_u256,
         best_block_hash: 0x000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55_u256
             .into(),
@@ -52,7 +99,7 @@ fn test_block170() {
     assert!(next_chain_state.is_ok(), "Error: {:?}", next_chain_state.err());
 
     let result = next_chain_state.unwrap();
-    assert_eq!(result.block_height.unwrap(), 170);
+    assert_eq!(result.block_height, 170);
     // assert_eq!(result.total_work, ?);
     assert_eq!(
         result.prev_timestamps,
@@ -74,7 +121,10 @@ fn test_block170() {
         result.current_target, 0x00000000ffff0000000000000000000000000000000000000000000000000000
     );
     assert_eq!(result.epoch_start_time, 1231006505);
+    assert_eq!(
+        result.best_block_hash,
+        0x00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee_u256.into()
+    );
     //to impl
-// assert_eq!(result.best_block_hash, 0_u256.into());
 // assert_eq!(result.utreexo_state.roots, [...]);
 }


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #114 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->
Use u32 for block height instead of option
Remove next block height helper, now it's just +1
Update ChainStateDefault implementation
Update tests using genesis block to use another one
Exclude genesis block from the script
