### PR TITLE
Fix: incorrect calculation of the previous block time median

### DIFF
--- a/src/validation/timestamp.cairo
+++ b/src/validation/timestamp.cairo
@@ -1,6 +1,7 @@
 //! Block time validation helpers.
 //!
 //! Read more: https://learnmeabitcoin.com/technical/block/time/
+use core::dict::Felt252Dict;
 
 /// Check that the block time is greater than the median of the 11 most recent timestamps.
 pub fn validate_timestamp(prev_timestamps: Span<u32>, block_time: u32) -> Result<(), ByteArray> {
@@ -12,7 +13,27 @@ pub fn validate_timestamp(prev_timestamps: Span<u32>, block_time: u32) -> Result
     // So we cannot assume the list of previous timestamps is sorted.
     // We still want to preserve the "queue" semantics, so we cannot do sorted insert.
     // Thus we need to sort the items in the prev_timestamps before picking a median.
-    if block_time > *prev_timestamps.at(prev_timestamps.len() - 6) {
+    // sort the prev_timestamps
+    let mut sorted_prev_timestamps: Array<u32> = array![];
+    let mut visited: Felt252Dict<bool> = Default::default();
+    while sorted_prev_timestamps.len() != prev_timestamps.len() {
+        let mut min_idx: Option<u32> = Option::None;
+        for i in 0..prev_timestamps.len() {
+            if !visited.get(i.into()) {
+                if min_idx.is_none() || prev_timestamps[i] < prev_timestamps[min_idx.unwrap()] {
+                    min_idx = Option::Some(i);
+                }
+            }
+        };
+        if let Option::Some(idx) = min_idx {
+            sorted_prev_timestamps.append(*prev_timestamps[idx]);
+            visited.insert(idx.into(), bool::True);
+        } else {
+            break;
+        }
+    };
+    
+    if block_time > *sorted_prev_timestamps.at(sorted_prev_timestamps.len() - 6) {
         Result::Ok(())
     } else {
         Result::Err("Median time is greater than or equal to block's timestamp")
@@ -59,5 +80,26 @@ mod tests {
         let next_prev_timestamps = next_prev_timestamps(prev_timestamps, block_time);
         assert_eq!(next_prev_timestamps.len(), 11);
         assert_eq!(next_prev_timestamps, array![2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].span());
+    }
+
+    #[test]
+    fn test_validate_timestamp_unchronological(){
+        let prev_timestamps = array![1,2,3,4,5,7,6,8,9,10,11].span();
+        let mut block_time = 12_u32;
+
+
+        // new timestamp is greater than the last timestamp
+        let result = validate_timestamp(prev_timestamps, block_time);
+        assert(result.is_ok(), 'Expected target to be valid');
+
+        // new timestamp is strictly greater than the median of the last 11 timestamps(sorted)
+        block_time = 7;
+        let result = validate_timestamp(prev_timestamps, block_time);
+        assert(result.is_ok(), 'Expected target to be valid');
+
+        // new timestamp is equal to the median of the last 11 timestamps(sorted)
+        block_time = 6;
+        let result = validate_timestamp(prev_timestamps, block_time);
+        assert!(result.is_err(), "Median time is greater than block's timestamp");
     }
 }

--- a/src/validation/timestamp.cairo
+++ b/src/validation/timestamp.cairo
@@ -1,38 +1,42 @@
 //! Block time validation helpers.
 //!
 //! Read more: https://learnmeabitcoin.com/technical/block/time/
-use core::dict::Felt252Dict;
 
 /// Check that the block time is greater than the median of the 11 most recent timestamps.
 pub fn validate_timestamp(prev_timestamps: Span<u32>, block_time: u32) -> Result<(), ByteArray> {
-    // FIXME: it's possible that one block could have an earlier timestamp
-    // than a block that came before it in the chain. Example:
-    //   - Block 156,114 = 05 Dec 2011, 06:17 (1 hour 59 minutes "before" the previous block)
-    //   - Block 156,113 = 05 Dec 2011, 08:16
-    //
-    // So we cannot assume the list of previous timestamps is sorted.
-    // We still want to preserve the "queue" semantics, so we cannot do sorted insert.
-    // Thus we need to sort the items in the prev_timestamps before picking a median.
-    // sort the prev_timestamps
+    // Sort the last 11 timestamps
+    // adapted from :
+    // https://github.com/keep-starknet-strange/alexandria/blob/main/packages/sorting/src/bubble_sort.cairo
+    let mut idx1 = 0;
+    let mut idx2 = 1;
+    let mut sorted_iteration = true;
+    let mut prev_timestamps: Span<u32> = prev_timestamps.clone();
     let mut sorted_prev_timestamps: Array<u32> = array![];
-    let mut visited: Felt252Dict<bool> = Default::default();
-    while sorted_prev_timestamps.len() != prev_timestamps.len() {
-        let mut min_idx: Option<u32> = Option::None;
-        for i in 0..prev_timestamps.len() {
-            if !visited.get(i.into()) {
-                if min_idx.is_none() || prev_timestamps[i] < prev_timestamps[min_idx.unwrap()] {
-                    min_idx = Option::Some(i);
-                }
+
+    loop {
+        if idx2 == prev_timestamps.len() {
+            sorted_prev_timestamps.append(*prev_timestamps[idx1]);
+            if sorted_iteration {
+                break;
+            }
+            prev_timestamps = sorted_prev_timestamps.span();
+            sorted_prev_timestamps = array![];
+            idx1 = 0;
+            idx2 = 1;
+            sorted_iteration = true;
+        } else {
+            if *prev_timestamps[idx1] <= *prev_timestamps[idx2] {
+                sorted_prev_timestamps.append(*prev_timestamps[idx1]);
+                idx1 = idx2;
+                idx2 += 1;
+            } else {
+                sorted_prev_timestamps.append(*prev_timestamps[idx2]);
+                idx2 += 1;
+                sorted_iteration = false;
             }
         };
-        if let Option::Some(idx) = min_idx {
-            sorted_prev_timestamps.append(*prev_timestamps[idx]);
-            visited.insert(idx.into(), bool::True);
-        } else {
-            break;
-        }
     };
-    
+
     if block_time > *sorted_prev_timestamps.at(sorted_prev_timestamps.len() - 6) {
         Result::Ok(())
     } else {
@@ -83,10 +87,29 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_timestamp_unchronological(){
-        let prev_timestamps = array![1,2,3,4,5,7,6,8,9,10,11].span();
+    fn test_validate_timestamp_single_unchronological() {
+        let prev_timestamps = array![1, 2, 3, 4, 5, 7, 6, 8, 9, 10, 11].span();
         let mut block_time = 12_u32;
 
+        // new timestamp is greater than the last timestamp
+        let result = validate_timestamp(prev_timestamps, block_time);
+        assert(result.is_ok(), 'Expected target to be valid');
+
+        // new timestamp is strictly greater than the median of the last 11 timestamps(sorted)
+        block_time = 7;
+        let result = validate_timestamp(prev_timestamps, block_time);
+        assert(result.is_ok(), 'Expected target to be valid');
+
+        // new timestamp is equal to the median of the last 11 timestamps(sorted)
+        block_time = 6;
+        let result = validate_timestamp(prev_timestamps, block_time);
+        assert!(result.is_err(), "Median time is greater than block's timestamp");
+    }
+
+    #[test]
+    fn test_validate_timestamp_unsorted() {
+        let prev_timestamps = array![1, 3, 2, 5, 4, 6, 8, 7, 9, 10, 11].span();
+        let mut block_time = 12_u32;
 
         // new timestamp is greater than the last timestamp
         let result = validate_timestamp(prev_timestamps, block_time);


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] Fixes #111
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->

# Description

Add O(n^2) sorting algorithm for sorting previous timestamp array. Test is included for unchronogical order of timestamp which may lead to incorrect median calculation, and the validation result might be incorrect.
