### PR TITLE
cheaper DigestIntoU256 (10x) and U256IntoDigest (2x)

### DIFF
--- a/src/utils/hash.cairo
+++ b/src/utils/hash.cairo
@@ -57,8 +57,8 @@ const NZ_POW2_32_64: NonZero<u64> = 0x100000000;
 /// u256 is big-endian like in explorer, while Digest is little-endian order.
 pub impl U256IntoDigest of Into<u256, Digest> {
     fn into(self: u256) -> Digest {
-        let mut low: u128 = u128_byte_reverse(self.high);
-        let mut high: u128 = u128_byte_reverse(self.low);
+        let low: u128 = u128_byte_reverse(self.high);
+        let high: u128 = u128_byte_reverse(self.low);
 
         let (q_96, high_32_0) = DivRem::div_rem(high, NZ_POW2_32_128);
         let (q_64, high_64_32) = DivRem::div_rem(q_96, NZ_POW2_32_128);


### PR DESCRIPTION
Gas for `test_hash_to_u256` went from 1 850 000 to 183 852
Gas for `test_u256_into_hash` went from  1 385 632 to 751052