### PR TITLE
TraceContext draft

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -3,6 +3,11 @@ name = "raito"
 version = "0.1.0"
 edition = "2024_07"
 
+[features]
+default = ["trace_context"]
+trace_context = []
+without_trace_context = []
+
 [scripts]
 regenerate_tests= "./scripts/data/regenerate_tests.sh"
 integration_tests = "scarb build && ./scripts/data/integration_tests.sh"

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -23,6 +23,7 @@ pub mod types {
     pub mod block;
     pub mod transaction;
     pub mod utxo_set;
+    pub mod context;
 }
 
 mod main;

--- a/src/types/context.cairo
+++ b/src/types/context.cairo
@@ -55,7 +55,7 @@ pub impl TraceContextImpl of TraceContextTrait {
     }
 
     fn trace(ref self: TraceContext, message: ByteArray) {
-        self.trace.append(message);
+        self.trace.append(self.with_context(message));
     }
 }
 

--- a/src/types/context.cairo
+++ b/src/types/context.cairo
@@ -100,6 +100,10 @@ mod trace_context_impl {
 
 #[cfg(feature: "trace_context")]
 pub use trace_context_impl::TraceContext;
-
 #[cfg(feature: "trace_context")]
+pub use trace_context_impl::TraceContextImpl;
+
+#[cfg(feature: "without_trace_context")]
+pub use trace_context_impl::TraceContext;
+#[cfg(feature: "without_trace_context")]
 pub use trace_context_impl::TraceContextImpl;

--- a/src/types/context.cairo
+++ b/src/types/context.cairo
@@ -1,0 +1,61 @@
+use crate::utils::hash::Digest;
+use core::dict::Felt252Dict;
+use core::nullable::NullableImpl;
+
+#[derive(Copy, Drop, Debug)]
+pub enum Frame {
+    BlockHeight: u32,
+    Transaction: u32,
+    TxIn: (Digest, u32),
+    TxOut: u32,
+    Message: @ByteArray,
+}
+
+pub struct TraceContext {
+    frames: Felt252Dict<Nullable<Frame>>,
+    len: u32,
+    trace: Array<ByteArray>,
+}
+
+impl DestructTraceContext of Destruct<TraceContext> {
+    fn destruct(self: TraceContext) nopanic {
+        self.frames.squash();
+    }
+}
+
+#[generate_trait]
+pub impl TraceContextImpl of TraceContextTrait {
+    fn new() -> TraceContext {
+        TraceContext { frames: Default::default(), len: 0, trace: array![] }
+    }
+
+    fn push(ref self: TraceContext, frame: Frame) {
+        self.frames.insert(self.len.into(), NullableImpl::new(frame));
+        self.len += 1;
+    }
+
+    fn pop(ref self: TraceContext) {
+        assert!(self.len > 0, "pop from empty context!");
+        self.len -= 1;
+    }
+
+    fn with_context(ref self: TraceContext, error: ByteArray) -> ByteArray {
+        let mut r: ByteArray = Default::default();
+        for f in 0
+            ..self.len - 1 {
+                r.append(@format!("{:?}/", self.frames.get(f.into()).deref()));
+            };
+        r.append(@": ");
+        r.append(@error);
+        return r;
+    }
+
+    fn err_with_context<T>(ref self: TraceContext, error: ByteArray) -> Result<T, ByteArray> {
+        Result::Err(self.with_context(error))
+    }
+
+    fn trace(ref self: TraceContext, message: ByteArray) {
+        self.trace.append(message);
+    }
+}
+

--- a/src/validation/block.cairo
+++ b/src/validation/block.cairo
@@ -1,5 +1,6 @@
 //! Block validation helpers.
 use crate::types::transaction::{Transaction};
+use crate::types::context::{TraceContext, Frame, TraceContextTrait};
 use crate::codec::{Encode, TransactionCodec};
 use crate::utils::{hash::Digest, merkle_tree::merkle_root, sha256::double_sha256_byte_array};
 use super::transaction::validate_transaction;
@@ -27,7 +28,7 @@ pub fn validate_block_weight(weight: usize) -> Result<(), ByteArray> {
 ///  - wTXID commitment (only for blocks after Segwit upgrade, otherwise return zero hash)
 ///  - Block weight
 pub fn compute_and_validate_tx_data(
-    txs: Span<Transaction>, block_height: u32, block_time: u32
+    ref context: TraceContext, txs: Span<Transaction>, block_height: u32, block_time: u32
 ) -> Result<(u64, Digest, Digest), ByteArray> {
     let mut txids: Array<Digest> = array![];
     let mut wtxids: Array<Digest> = array![];
@@ -40,6 +41,8 @@ pub fn compute_and_validate_tx_data(
             break Result::Ok(());
         }
         ///  - wTXID commitment (only for blocks after Segwit upgrade, otherwise return zero hash)
+
+        context.push(Frame::Transaction(i));
 
         let tx = txs[i];
         let tx_bytes_legacy = @tx.encode();
@@ -59,7 +62,7 @@ pub fn compute_and_validate_tx_data(
 
         // skipping the coinbase transaction
         if (i != 0) {
-            let fee = match validate_transaction(tx, block_height, block_time) {
+            let fee = match validate_transaction(ref context, tx, block_height, block_time) {
                 Result::Ok(fee) => fee,
                 Result::Err(err) => { break Result::Err(err); }
             };

--- a/src/validation/transaction.cairo
+++ b/src/validation/transaction.cairo
@@ -38,8 +38,6 @@ pub fn validate_transaction(
 
     context.push(Frame::Message(@"validate_transaction"));
 
-    println!("context: {:?}", context);
-
     if (*tx.inputs).len() == 0 {
         return context.err_with_context("transaction inputs are empty");
     };


### PR DESCRIPTION
Draft of `TraceContext`. Maintains context which allows to construct more meaningful errors and trace messages.

Initialization:
```
        let mut context = TraceContextTrait::new();
        context.push(Frame::BlockHeight(block_height));
```
Errors:
```
    maturity_result = context
        .err_with_context(
            format!(
                "coinbase input not mature (current height: {}, coinbase height: {})",
                block_height,
                coinbase_block_height
            )
        );
```
`Frame` struct is a very rough draft, subject for discussion.

With macros or conditional compilation(to be added later to the prototype) most of the runtime cost can be eliminated for provable(vs test) executions.

Even with macros I don't see a clean way to get rid of explicit context argument. Any ideas? Maybe it is ok to add let's say 5% to the proving cost for current simplicity of the construction?
