### PR TITLE
Ignore cached flag when hashing outpoint

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,3 +11,4 @@ license-file = "LICENSE"
 
 [workspace.dependencies]
 cairo_test = "2.8.0"
+

--- a/packages/consensus/src/types/transaction.cairo
+++ b/packages/consensus/src/types/transaction.cairo
@@ -105,7 +105,7 @@ pub struct OutPoint {
 /// Output of a transaction.
 /// https://learnmeabitcoin.com/technical/transaction/output/
 ///
-/// NOTE that `cached` meta field is not serialized with the rest of the output data, 
+/// NOTE: that `cached` meta field is not serialized with the rest of the output data,
 /// so it's not constrained by the transaction hash.
 ///
 /// Upon processing (validating) an output one of three actions must be taken:
@@ -129,8 +129,10 @@ pub struct TxOut {
 
 ///
 /// Custom implementation of the Hash trait for TxOut removed cached field.
-/// 
-impl TxOutHash<S, impl SHashState: core::hash::HashStateTrait<S>, +Drop<S>> of core::hash::Hash<TxOut, S, SHashState> {
+///
+impl TxOutHash<
+    S, impl SHashState: core::hash::HashStateTrait<S>, +Drop<S>
+> of core::hash::Hash<TxOut, S, SHashState> {
     #[inline(always)]
     fn update_state(state: S, value: TxOut) -> S {
         let state = Hash::update_state(state, value.value);

--- a/packages/consensus/src/types/transaction.cairo
+++ b/packages/consensus/src/types/transaction.cairo
@@ -236,12 +236,24 @@ mod tests {
             pk_script: @"410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
             cached: false,
         };
-        let mut tx2 = TxOut {
+        let mut tx_with_cached_changed = TxOut {
             value: 50_u64,
             pk_script: @"410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
             cached: true,
         };
-        assert_eq!(tx1.hash(), tx2.hash());
+        let mut tx_with_value_changed = TxOut {
+            value: 55_u64,
+            pk_script: @"410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
+            cached: false,
+        };
+        let mut tx_with_pk_script_changed = TxOut {
+            value: 50_u64,
+            pk_script: @"510411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
+            cached: false,
+        };
+        assert_eq!(tx1.hash(), tx_with_cached_changed.hash());
+        assert_ne!(tx1.hash(), tx_with_pk_script_changed.hash());
+        assert_ne!(tx1.hash(), tx_with_value_changed.hash());
     }
 
     #[test]

--- a/packages/consensus/src/types/utxo_set.cairo
+++ b/packages/consensus/src/types/utxo_set.cairo
@@ -149,11 +149,13 @@ mod tests {
     fn test_not_include_unspendable_utxo() {
         let mut utxo_set: UtxoSet = Default::default();
         utxo_set.add(dummy_outpoint(0, false)).unwrap();
-        utxo_set.add(dummy_unspendable_outpoint(0, false));
+        let _ = utxo_set.add(dummy_unspendable_outpoint(0, false));
+    
         utxo_set.add(dummy_outpoint(1, true)).unwrap();
-        utxo_set.add(dummy_unspendable_outpoint(1, true));
+        let _ = utxo_set.add(dummy_unspendable_outpoint(1, true));
+        
         utxo_set.add(dummy_outpoint(2, false)).unwrap();
-        utxo_set.add(dummy_unspendable_outpoint(2, false));
+        let _ = utxo_set.add(dummy_unspendable_outpoint(2, false));
 
         assert_eq!(utxo_set.leaves_to_add.len(), 2);
         assert_eq!(utxo_set.leaves_to_delete.len(), 0);
@@ -220,7 +222,7 @@ mod tests {
     fn test_poseidon1() {
         let outpoint: OutPoint = get_outpoint();
         let outpoint_hash = PoseidonTrait::new().update_with(outpoint).finalize();
-        let expected: felt252 = 0x1E75C4C86C74C8808E45065A0591C850B3B3961C06F78DEFD12A55C2E4987CD;
+        let expected: felt252 = 0x3945D2584EE5EF0B482B70CD63E0E8CD18827CB348F839D1E6EB8ECBB2B397D;
         assert_eq!(outpoint_hash, expected);
     }
 }

--- a/packages/consensus/src/types/utxo_set.cairo
+++ b/packages/consensus/src/types/utxo_set.cairo
@@ -150,10 +150,10 @@ mod tests {
         let mut utxo_set: UtxoSet = Default::default();
         utxo_set.add(dummy_outpoint(0, false)).unwrap();
         let _ = utxo_set.add(dummy_unspendable_outpoint(0, false));
-    
+
         utxo_set.add(dummy_outpoint(1, true)).unwrap();
         let _ = utxo_set.add(dummy_unspendable_outpoint(1, true));
-        
+
         utxo_set.add(dummy_outpoint(2, false)).unwrap();
         let _ = utxo_set.add(dummy_unspendable_outpoint(2, false));
 


### PR DESCRIPTION
- [x] resolves #233
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

Updated wrong comment for OutPoint
Updated python scripts to use OrderedDict for easier data manipulation, updated code, excluded cached flag in hash calculation.
Updated tests. IMPORTANT: please review, I didn't try make hashes compatible.
Regenerated test files.

This fixes issue: #233
