### PR TITLE
feat: make bits_to_target 7 times faster

### DIFF
--- a/packages/consensus/src/validation/difficulty.cairo
+++ b/packages/consensus/src/validation/difficulty.cairo
@@ -4,7 +4,7 @@
 //!   - https://learnmeabitcoin.com/technical/mining/target/
 //!   - https://learnmeabitcoin.com/technical/block/bits/
 
-use utils::{bit_shifts::{shl, shr_u64, fast_pow}};
+use utils::bit_shifts::fast_pow;
 
 /// Maximum difficulty target allowed
 const MAX_TARGET: u256 = 0x00000000FFFF0000000000000000000000000000000000000000000000000000;

--- a/packages/utils/src/bit_shifts.cairo
+++ b/packages/utils/src/bit_shifts.cairo
@@ -1,38 +1,6 @@
 //! Bit shifts.
 
-use core::num::traits::{Zero, One, BitSize};
-
-/// Performs a bitwise left shift on the given value by a specified number of bits.
-pub fn shl<
-    T,
-    U,
-    +Zero<T>,
-    +Zero<U>,
-    +One<T>,
-    +One<U>,
-    +Add<T>,
-    +Add<U>,
-    +Sub<U>,
-    +Mul<T>,
-    +Div<U>,
-    +Rem<U>,
-    +Copy<T>,
-    +Copy<U>,
-    +Drop<T>,
-    +Drop<U>,
-    +PartialOrd<U>,
-    +PartialEq<U>,
-    +BitSize<T>,
-    +Into<usize, U>
->(
-    self: T, shift: U,
-) -> T {
-    if shift > BitSize::<T>::bits().into() - One::one() {
-        return Zero::zero();
-    }
-    let two = One::one() + One::one();
-    self * fast_pow(two, shift)
-}
+use core::num::traits::{Zero, One};
 
 /// Performs a bitwise right shift on a u64 value by a specified number of bits.
 /// This specialized version offers optimal performance for u64 types.
@@ -178,7 +146,7 @@ pub fn pow2(exponent: u32) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{fast_pow, pow2, shl, shr_u64};
+    use super::{fast_pow, pow2, shr_u64};
 
     #[test]
     #[available_gas(1000000000)]
@@ -201,19 +169,6 @@ mod tests {
         assert_eq!(pow2(10), 1024, "2^10 should be 1024");
         assert_eq!(pow2(63), 0x8000000000000000, "2^63 should be 0x8000000000000000");
         assert_eq!(pow2(63), 0x8000000000000000, "2^64 should be 0x8000000000000000");
-    }
-
-    #[test]
-    fn test_shl() {
-        let value1: u32 = 3;
-        let shift1: u32 = 2;
-        let result = shl(value1, shift1);
-        assert_eq!(result, 12, "invalid result");
-
-        let value2: u32 = 5;
-        let shift2: u32 = 0;
-        let result = shl(value2, shift2);
-        assert_eq!(result, 5);
     }
 
     #[test]


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] resolves #277
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->

## Changes implemented:
I initially wanted to use a lookup table to hardcode the mantissa factor and rely on field arithmetics to not have to make a separate code for divison, unfortunately because the result needs to be truncated, this trick doesn't work. Instead I created a big match to hardcode the operation to apply to the mantissa, this allowed me to remove the `shl` function. `shr` was already optimized but we still get a 7x performance gain on some tests. 

I also took this as an opportunity to optimize the u256 multiplication (when I could skip the divrem and hardcode the low and high of u256). I justified all the math simplifications in comments.

## Performance improvements:

Previous implementation:
```
test consensus::validation::difficulty::tests::test_bits_to_target_02008000 ... ok (gas usage est.: 51610)
test consensus::validation::difficulty::tests::test_bits_to_target_05009234 ... ok (gas usage est.: 220960)
test consensus::validation::difficulty::tests::test_bits_to_target_181bc330 ... ok (gas usage est.: 322570)
test consensus::validation::difficulty::tests::test_bits_to_target_04123456 ... ok (gas usage est.: 187090)
test consensus::validation::difficulty::tests::test_bits_to_target_01123456 ... ok (gas usage est.: 51610)
test consensus::validation::difficulty::tests::test_bits_to_target_1d00ffff ... ok (gas usage est.: 322570)
test consensus::validation::difficulty::tests::test_bits_to_target_1c0d3142 ... ok (gas usage est.: 322570)
test consensus::validation::difficulty::tests::test_bits_to_target_01003456 ... ok (gas usage est.: 51610)
test consensus::validation::difficulty::tests::test_bits_to_target_1707a429 ... ok (gas usage est.: 322570)
test consensus::validation::difficulty::tests::test_bits_to_target_bounds ... ok (gas usage est.: 680290)
test result: ok. 10 passed; 0 failed; 0 ignored; 89 filtered out;
```

New implementation:
```
test consensus::validation::difficulty::tests::test_bits_to_target_1707a429 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_181bc330 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_05009234 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_01003456 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_04123456 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_1c0d3142 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_02008000 ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_1d00ffff ... ok (gas usage est.: 42520)
test consensus::validation::difficulty::tests::test_bits_to_target_bounds ... ok (gas usage est.: 382060)
test consensus::validation::difficulty::tests::test_bits_to_target_01123456 ... ok (gas usage est.: 42520)
test result: ok. 10 passed; 0 failed; 0 ignored; 89 filtered out;
```


