### PR TITLE
Switch to scarb execute for running the client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.9.1"
+          scarb-version: "nightly-2025-05-24"
       - run: scarb --version
       - run: scarb fmt --check
-      - run: scarb build
+      - run: scarb --profile proving build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.9.1"
+          scarb-version: "nightly-2025-05-24"
       - run: scarb --version
       - run: scarb test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-scarb 2.9.1
+scarb nightly-2025-05-24

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	scarb --profile proving build --target-kinds executable
+
+build-with-shinigami:
+	sed -i '' 's/default = \[\]/default = ["shinigami"]/' packages/consensus/Scarb.toml
+	scarb --profile proving build --target-kinds executable
+	sed -i '' 's/default = \["shinigami"\]/default = []/' packages/consensus/Scarb.toml

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ pip install -r scripts/data/requirements.txt
 - [Cairo](https://www.cairo-lang.org/)
 - [Circle STARK paper](https://eprint.iacr.org/2024/278)
 
+## Name reference
+
+Raito is a reference to Light Yagami (夜神月, Yagami Raito) from the manga/anime Death Note.
+
+- Raito in Japanese means "Light", which in turns can refer to Lightning ⚡ (and hence both a reference to speed of verification of the Bitcoin blockchain using a ZKP and a reference to the Lightning Network)
+- Raito can work in tandem with [Shinigami](https://github.com/keep-starknet-strange/shinigami) that enables verification of Bitcoin Script programs. Raito = Consensus and Raito = Execution. Since Shinigami was named after Ryuk (Shinigami in Death Note), Raito was named after Light (Raito in Death Note).
+- What Raito writes in the Death Note always happen, so you can see it as a source of truth, similarly to how you use a Zero-Knowledge Proof to verify the integrity of a computation.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -3,18 +3,18 @@ members = ["packages/*"]
 
 [workspace.package]
 description = "Bitcoin ZK client."
-cairo-version = "2.9.1"
+cairo-version = "2.11.4"
 version = "0.1.0"
 readme = "README.md"
 repository = "https://github.com/keep-starknet-strange/raito"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-cairo_test = "2.9.1"
+cairo_test = "2.11.4"
 shinigami_engine = { git = "https://github.com/keep-starknet-strange/shinigami.git", rev = "1963116" }
 
-[profile.cairo1-run.cairo]
-# https://github.com/lambdaclass/cairo-vm/issues/1745
+[profile.proving]
+inherits = "release"
+
+[profile.proving.cairo]
 enable-gas = false
-# https://github.com/software-mansion/scarb/blob/4d91be7a7dbfeb24327e3ba21c62fbac43a2105a/scarb/src/compiler/compilers/lib.rs#L154
-sierra-replace-ids = true

--- a/packages/client/Scarb.toml
+++ b/packages/client/Scarb.toml
@@ -3,7 +3,11 @@ name = "client"
 version = "0.1.0"
 edition = "2024_07"
 
+[executable]
+allow-syscalls = true
+
 [dependencies]
+cairo_execute = "2.11.4"
 consensus = { path = "../consensus" }
 utreexo = { path = "../utreexo" }
 
@@ -11,7 +15,7 @@ utreexo = { path = "../utreexo" }
 cairo_test.workspace = true
 
 [scripts]
-test = "scarb build && ../../scripts/data/integration_tests.sh"
+test = "scarb --profile proving build && ../../scripts/data/integration_tests.sh"
 regenerate_tests= "../../scripts/data/regenerate_tests.sh"
 client = "scarb build && ../../scripts/data/client.sh"
 lint = "black ../../scripts/data && flake8 ../../scripts/data --max-complexity=10 --max-line-length=88 && scarb fmt"

--- a/packages/client/tests/data/ignore
+++ b/packages/client/tests/data/ignore
@@ -1,0 +1,2 @@
+full_774627.json
+full_839999.json

--- a/packages/client/tests/data/ignore
+++ b/packages/client/tests/data/ignore
@@ -1,2 +1,1 @@
 full_774627.json
-full_839999.json

--- a/packages/consensus/Scarb.toml
+++ b/packages/consensus/Scarb.toml
@@ -11,5 +11,8 @@ shinigami_engine.workspace = true
 cairo_test.workspace = true
 
 [scripts]
-# TODO: cairo lint
 lint = "scarb fmt"
+
+[features]
+default = []
+shinigami = []

--- a/packages/consensus/src/codec.cairo
+++ b/packages/consensus/src/codec.cairo
@@ -1,10 +1,10 @@
 //! Bitcoin binary codec traits, implementations, and helpers.
 
-use super::types::transaction::{Transaction, TxIn, TxOut, OutPoint};
+use core::serde::Serde;
+use core::traits::DivRem;
 use utils::hash::Digest;
 use utils::word_array::{WordArray, WordArrayTrait, WordSpan, WordSpanTrait};
-use core::traits::DivRem;
-use core::serde::Serde;
+use super::types::transaction::{OutPoint, Transaction, TxIn, TxOut};
 
 pub trait Encode<T> {
     /// Encodes using Bitcoin codec and appends to the buffer.
@@ -47,7 +47,7 @@ pub impl EncodeByteArray of Encode<ByteArray> {
         while num_bytes31 != 0 {
             dest.append_bytes31(out.pop_front().unwrap());
             num_bytes31 -= 1;
-        };
+        }
 
         let last_word = out.pop_front().unwrap();
         let last_word_len = out.pop_front().unwrap();
@@ -134,11 +134,11 @@ pub impl TransactionCodecImpl of TransactionCodec {
         // Rest of the tx (except locktime)
         while let Option::Some((word, num_bytes)) = tx_words.pop_front() {
             dest.append_word(word, num_bytes);
-        };
+        }
         // Append witness data
         for txin in *self.inputs {
             txin.witness.encode_to(ref dest);
-        };
+        }
         // Append locktime
         dest.append_word(lock_time_word, 4);
 
@@ -167,10 +167,11 @@ pub fn encode_compact_size(len: usize, ref dest: WordArray) {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::transaction::{Transaction, TxIn, TxOut, OutPoint};
-    use super::{Encode, TransactionCodec, encode_compact_size};
     use utils::hex::{from_hex, hex_to_hash_rev};
-    use utils::word_array::{WordArrayTrait, hex::words_from_hex};
+    use utils::word_array::WordArrayTrait;
+    use utils::word_array::hex::words_from_hex;
+    use crate::types::transaction::{OutPoint, Transaction, TxIn, TxOut};
+    use super::{Encode, TransactionCodec, encode_compact_size};
 
     #[test]
     fn test_encode_compact_size1() {

--- a/packages/consensus/src/lib.cairo
+++ b/packages/consensus/src/lib.cairo
@@ -10,7 +10,21 @@ pub mod validation {
     pub mod coinbase;
     pub mod difficulty;
     pub mod locktime;
+
+    // TODO: once Scarb supports feature propagation, pass it from the client
+    #[cfg(feature: "shinigami")]
     pub mod script;
+
+    #[cfg(not(feature: "shinigami"))]
+    pub mod script {
+        use crate::types::block::Header;
+        use crate::types::transaction::Transaction;
+
+        pub fn validate_scripts(header: @Header, txs: Span<Transaction>) -> Result<(), ByteArray> {
+            Result::Ok(())
+        }
+    }
+
     pub mod timestamp;
     pub mod transaction;
     pub mod work;

--- a/packages/consensus/src/types/block.cairo
+++ b/packages/consensus/src/types/block.cairo
@@ -2,11 +2,11 @@
 //!
 //! The data is expected to be prepared in advance and passed as program arguments.
 
-use core::fmt::{Display, Formatter, Error};
-use super::transaction::Transaction;
-use utils::hash::Digest;
+use core::fmt::{Display, Error, Formatter};
 use utils::double_sha256::double_sha256_word_array;
+use utils::hash::Digest;
 use utils::word_array::{WordArray, WordArrayTrait};
+use super::transaction::Transaction;
 
 /// Represents a block in the blockchain.
 #[derive(Drop, Copy, Debug, PartialEq, Default, Serde)]
@@ -113,16 +113,16 @@ impl TransactionDataDisplay of Display<TransactionData> {
             TransactionData::Transactions(txs) => f
                 .buffer
                 .append(@format!("Transactions: {}", txs.len())),
-        };
+        }
         Result::Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::types::chain_state::ChainState;
-    use super::{Header, BlockHash};
     use utils::hash::Digest;
+    use crate::types::chain_state::ChainState;
+    use super::{BlockHash, Header};
 
     #[test]
     fn test_block_hash() {

--- a/packages/consensus/src/types/transaction.cairo
+++ b/packages/consensus/src/types/transaction.cairo
@@ -3,10 +3,11 @@
 //! Types are extended with extra information required for validation.
 //! The data is expected to be prepared in advance and passed as program arguments.
 
-use core::fmt::{Display, Formatter, Error};
-use core::hash::{HashStateTrait, HashStateExTrait, Hash};
+use core::fmt::{Display, Error, Formatter};
+use core::hash::{Hash, HashStateExTrait, HashStateTrait};
 use core::poseidon::PoseidonTrait;
-use utils::{hash::Digest, bytearray::{ByteArraySnapHash, ByteArraySnapSerde}};
+use utils::bytearray::{ByteArraySnapHash, ByteArraySnapSerde};
+use utils::hash::Digest;
 
 /// Represents a transaction.
 /// https://learnmeabitcoin.com/technical/transaction/
@@ -224,8 +225,8 @@ impl TxOutDisplay of Display<TxOut> {
 #[cfg(test)]
 mod tests {
     use core::poseidon::PoseidonTrait;
-    use utils::hex::{hex_to_hash_rev, from_hex};
-    use super::{OutPoint, TxOut, HashStateTrait, HashStateExTrait, OutPointHashTrait};
+    use utils::hex::{from_hex, hex_to_hash_rev};
+    use super::{HashStateExTrait, HashStateTrait, OutPoint, OutPointHashTrait, TxOut};
 
     fn hash(tx: @TxOut) -> felt252 {
         PoseidonTrait::new().update_with(*tx).finalize()
@@ -298,18 +299,11 @@ mod tests {
         state = state.update_with(coinbase_9_utxo);
 
         let expected: Array<felt252> = array![
-            5606656307511680658662848977137541728,
-            9103019671783490751638296454939121609,
-            0,
-            5000000000,
-            2,
+            5606656307511680658662848977137541728, 9103019671783490751638296454939121609, 0,
+            5000000000, 2,
             114873147639302600539941532864842037771792291166958548649371950632810924198,
             255491345418700057264349667014908841246825595399329019948869966327385048054,
-            372388307884,
-            5,
-            9,
-            1231470988,
-            1,
+            372388307884, 5, 9, 1231470988, 1,
         ];
         assert_eq!(expected, state.value);
 
@@ -342,18 +336,11 @@ mod tests {
         state = state.update_with(coinbase_9_utxo);
 
         let expected: Array<felt252> = array![
-            18931831195212887181660290436187791739,
-            137019159177035157628276746705882390680,
-            0,
-            5000000000,
-            2,
+            18931831195212887181660290436187791739, 137019159177035157628276746705882390680, 0,
+            5000000000, 2,
             114876729272917404712191936498804624660105992100397383656070609774475449467,
             406791163401893627439198994794895943141891052128672824792182596804809637667,
-            286829113004,
-            5,
-            1,
-            1231006505,
-            1,
+            286829113004, 5, 1, 1231006505, 1,
         ];
         assert_eq!(expected, state.value);
 

--- a/packages/consensus/src/types/utxo_set.cairo
+++ b/packages/consensus/src/types/utxo_set.cairo
@@ -9,8 +9,8 @@
 //! In order to prove that the UTXOs provided actually belong to the set we use either
 //! Utreexo accumulator or local cache.
 
-use core::dict::Felt252Dict;
 use consensus::validation::transaction::is_pubscript_unspendable;
+use core::dict::Felt252Dict;
 use super::transaction::{OutPoint, OutPointHashTrait};
 
 pub const TX_OUTPUT_STATUS_NONE: u8 = 0;
@@ -87,11 +87,11 @@ pub impl UtxoSetImpl of UtxoSetTrait {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::transaction::{TxOut, OutPoint};
-    use crate::types::utxo_set::{UtxoSet, UtxoSetTrait};
+    use core::hash::{HashStateExTrait, HashStateTrait};
     use core::poseidon::PoseidonTrait;
-    use core::hash::{HashStateTrait, HashStateExTrait};
     use utils::hex::{from_hex, hex_to_hash_rev};
+    use crate::types::transaction::{OutPoint, TxOut};
+    use crate::types::utxo_set::{UtxoSet, UtxoSetTrait};
 
     #[test]
     fn test_utxo_set_add() {

--- a/packages/consensus/src/validation/block.cairo
+++ b/packages/consensus/src/validation/block.cairo
@@ -1,12 +1,15 @@
 //! Block validation helpers.
 
 use core::num::traits::zero::Zero;
-use crate::types::utxo_set::{UtxoSet, UtxoSetTrait};
-use crate::types::transaction::{OutPoint, Transaction};
-use crate::codec::{Encode, TransactionCodec};
-use crate::validation::{coinbase::is_coinbase_txid_duplicated, transaction::validate_transaction};
-use utils::{hash::Digest, merkle_tree::merkle_root, double_sha256::double_sha256_word_array};
+use utils::double_sha256::double_sha256_word_array;
+use utils::hash::Digest;
+use utils::merkle_tree::merkle_root;
 use utils::word_array::WordArrayTrait;
+use crate::codec::{Encode, TransactionCodec};
+use crate::types::transaction::{OutPoint, Transaction};
+use crate::types::utxo_set::{UtxoSet, UtxoSetTrait};
+use crate::validation::coinbase::is_coinbase_txid_duplicated;
+use crate::validation::transaction::validate_transaction;
 
 const MAX_BLOCK_WEIGHT_LEGACY: usize = 1_000_000;
 const MAX_BLOCK_WEIGHT: usize = 4_000_000;
@@ -93,7 +96,7 @@ pub fn compute_and_validate_tx_data(
                     break;
                 }
                 vout += 1;
-            };
+            }
             is_coinbase = false;
         } else {
             let fee =
@@ -108,7 +111,7 @@ pub fn compute_and_validate_tx_data(
             };
             total_fee += fee;
         }
-    };
+    }
 
     inner_result?;
     validate_block_weight(total_weight)?;

--- a/packages/consensus/src/validation/difficulty.cairo
+++ b/packages/consensus/src/validation/difficulty.cairo
@@ -72,7 +72,7 @@ fn reduce_target_precision(target: u256) -> u256 {
     while num != 0 {
         num /= 256;
         size += 1;
-    };
+    }
 
     // Extract 3 most significant bytes and round down
     if size > 2 {
@@ -170,7 +170,7 @@ fn bits_to_target(bits: u32) -> Result<u256, ByteArray> {
 
 #[cfg(test)]
 mod tests {
-    use super::{bits_to_target, adjust_difficulty, reduce_target_precision};
+    use super::{adjust_difficulty, bits_to_target, reduce_target_precision};
 
     #[test]
     fn test_adjust_difficulty_block_2016_no_retargeting() {

--- a/packages/consensus/src/validation/locktime.cairo
+++ b/packages/consensus/src/validation/locktime.cairo
@@ -108,9 +108,9 @@ pub fn validate_relative_locktime(
 
 #[cfg(test)]
 mod tests {
-    use crate::types::transaction::{TxIn, OutPoint, TxOut};
-    use super::{validate_absolute_locktime, validate_relative_locktime};
     use utils::hex::{from_hex, hex_to_hash_rev};
+    use crate::types::transaction::{OutPoint, TxIn, TxOut};
+    use super::{validate_absolute_locktime, validate_relative_locktime};
 
     #[test]
     fn test_relative_locktime_disabled() {

--- a/packages/consensus/src/validation/script.cairo
+++ b/packages/consensus/src/validation/script.cairo
@@ -1,14 +1,13 @@
 //! Shinigami Bitcoin Script VM integration helpers.
 
-use crate::types::transaction::{Transaction, TxIn, TxOut};
-use crate::types::block::Header;
-use shinigami_engine::engine::EngineTrait;
-use shinigami_engine::engine::EngineImpl;
-use shinigami_engine::hash_cache::HashCacheImpl;
+use shinigami_engine::engine::{EngineImpl, EngineTrait};
 use shinigami_engine::flags::ScriptFlags;
+use shinigami_engine::hash_cache::HashCacheImpl;
 use shinigami_engine::transaction::{
     EngineTransactionInputTrait, EngineTransactionOutputTrait, EngineTransactionTrait,
 };
+use crate::types::block::Header;
+use crate::types::transaction::{Transaction, TxIn, TxOut};
 
 const BIP_16_BLOCK_HEIGHT: u32 = 173805; // Pay-to-Script-Hash (P2SH) 
 const BIP_66_BLOCK_HEIGHT: u32 = 363725; // DER Signatures 
@@ -140,7 +139,7 @@ fn parse_short_string(short: felt252) -> ByteArray {
     while f != 0 {
         f = f / 256;
         l += 1;
-    };
+    }
     let mut parsed: ByteArray = Default::default();
     parsed.append_word(short, l);
     parsed
@@ -177,7 +176,7 @@ fn validate_script(header: @Header, tx: @Transaction, tx_idx: u32) -> Result<(),
                 break;
             },
         }
-    };
+    }
 
     match result {
         Option::Some(err) => Result::Err(err),
@@ -195,7 +194,7 @@ pub fn validate_scripts(header: @Header, txs: Span<Transaction>) -> Result<(), B
             break;
         }
         i += 1;
-    };
+    }
 
     r
 }

--- a/packages/consensus/src/validation/timestamp.cairo
+++ b/packages/consensus/src/validation/timestamp.cairo
@@ -24,20 +24,18 @@ pub fn compute_median_time_past(prev_timestamps: Span<u32>) -> u32 {
             idx1 = 0;
             idx2 = 1;
             sorted_iteration = true;
+        } else if *prev_timestamps[idx1] <= *prev_timestamps[idx2] {
+            sorted_prev_timestamps.append(*prev_timestamps[idx1]);
+            idx1 = idx2;
+            idx2 += 1;
         } else {
-            if *prev_timestamps[idx1] <= *prev_timestamps[idx2] {
-                sorted_prev_timestamps.append(*prev_timestamps[idx1]);
-                idx1 = idx2;
-                idx2 += 1;
-            } else {
-                sorted_prev_timestamps.append(*prev_timestamps[idx2]);
-                idx2 += 1;
-                sorted_iteration = false;
-            }
-        };
-    };
+            sorted_prev_timestamps.append(*prev_timestamps[idx2]);
+            idx2 += 1;
+            sorted_iteration = false;
+        }
+    }
 
-    *sorted_prev_timestamps.at(sorted_prev_timestamps.len() / 2)
+    (*sorted_prev_timestamps.at(sorted_prev_timestamps.len() / 2))
 }
 
 /// Checks that the block time is greater than the Median Time Past (MTP).
@@ -65,7 +63,7 @@ pub fn next_prev_timestamps(prev_timestamps: Span<u32>, block_time: u32) -> Span
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_median_time_past, validate_timestamp, next_prev_timestamps};
+    use super::{compute_median_time_past, next_prev_timestamps, validate_timestamp};
 
     #[test]
     fn test_compute_median_time_past() {

--- a/packages/consensus/src/validation/transaction.cairo
+++ b/packages/consensus/src/validation/transaction.cairo
@@ -1,11 +1,11 @@
 //! Transaction validation helpers.
 
+use utils::hash::Digest;
 use crate::types::transaction::{OutPoint, Transaction};
 use crate::types::utxo_set::{UtxoSet, UtxoSetTrait};
 use crate::validation::locktime::{
     is_input_final, validate_absolute_locktime, validate_relative_locktime,
 };
-use utils::hash::Digest;
 
 const OP_RETURN: u8 = 0x6a;
 const MAX_SCRIPT_SIZE: u32 = 10000;
@@ -23,11 +23,11 @@ pub fn validate_transaction(
 ) -> Result<u64, ByteArray> {
     if (*tx.inputs).is_empty() {
         return Result::Err("transaction inputs are empty");
-    };
+    }
 
     if (*tx.outputs).is_empty() {
         return Result::Err("transaction outputs are empty");
-    };
+    }
 
     let mut inner_result: Result<(), ByteArray> = Result::Ok(());
 
@@ -61,7 +61,7 @@ pub fn validate_transaction(
         }
 
         total_input_amount += *input.previous_output.data.value;
-    };
+    }
 
     if inner_result.is_err() {
         return Result::Err(inner_result.unwrap_err());
@@ -90,7 +90,7 @@ pub fn validate_transaction(
 
         total_output_amount += *output.value;
         vout += 1;
-    };
+    }
 
     inner_result?;
     compute_transaction_fee(total_input_amount, total_output_amount)
@@ -136,11 +136,12 @@ pub fn is_pubscript_unspendable(pubscript: @ByteArray) -> bool {
 #[cfg(test)]
 mod tests {
     use core::dict::Felt252Dict;
+    use utils::double_sha256::double_sha256_word_array;
+    use utils::hex::{from_hex, hex_to_hash_rev};
     use crate::codec::Encode;
-    use crate::types::transaction::{Transaction, TxIn, TxOut, OutPoint, OutPointHashTrait};
-    use crate::types::utxo_set::{UtxoSet, TX_OUTPUT_STATUS_UNSPENT};
-    use super::{validate_transaction, is_pubscript_unspendable, MAX_SCRIPT_SIZE};
-    use utils::{hex::{from_hex, hex_to_hash_rev}, double_sha256::double_sha256_word_array};
+    use crate::types::transaction::{OutPoint, OutPointHashTrait, Transaction, TxIn, TxOut};
+    use crate::types::utxo_set::{TX_OUTPUT_STATUS_UNSPENT, UtxoSet};
+    use super::{MAX_SCRIPT_SIZE, is_pubscript_unspendable, validate_transaction};
 
     #[test]
     fn test_tx_fee() {
@@ -875,7 +876,7 @@ mod tests {
         let mut large_script: ByteArray = Default::default();
         for _ in 0..(MAX_SCRIPT_SIZE + 1) {
             large_script.append_byte(0x00);
-        };
+        }
         assert!(is_pubscript_unspendable(@large_script));
     }
 }

--- a/packages/consensus/src/validation/work.cairo
+++ b/packages/consensus/src/validation/work.cairo
@@ -33,7 +33,7 @@ fn compute_work_from_target(target: u256) -> u256 {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_proof_of_work, compute_work_from_target};
+    use super::{compute_work_from_target, validate_proof_of_work};
 
     #[test]
     fn test_validate_proof_of_work() {

--- a/packages/utils/Scarb.toml
+++ b/packages/utils/Scarb.toml
@@ -7,5 +7,4 @@ edition = "2024_07"
 cairo_test.workspace = true
 
 [scripts]
-# TODO: cairo lint
 lint = "scarb fmt"

--- a/packages/utils/src/bit_shifts.cairo
+++ b/packages/utils/src/bit_shifts.cairo
@@ -1,6 +1,6 @@
 //! Bit shifts and pow helpers.
 
-use core::num::traits::{Zero, One};
+use core::num::traits::{One, Zero};
 
 /// Performs a bitwise right shift on a `u64` value by a specified number of bits.
 /// This specialized version offers optimal performance for `u64` types.

--- a/packages/utils/src/bytearray.cairo
+++ b/packages/utils/src/bytearray.cairo
@@ -24,7 +24,7 @@ pub impl ByteArraySnapHash<S, +HashStateTrait<S>, +Drop<S>> of Hash<@ByteArray, 
 
         for felt in serialized_bytearray {
             state = state.update(felt);
-        };
+        }
 
         state
     }

--- a/packages/utils/src/double_sha256.cairo
+++ b/packages/utils/src/double_sha256.cairo
@@ -1,9 +1,8 @@
-use super::word_array::WordArrayTrait;
 //! Helpers for calculating double SHA256 hash digest.
 
 use super::hash::{Digest, DigestTrait};
 use super::sha256_core::compute_sha256_u32_array;
-use super::word_array::WordArray;
+use super::word_array::{WordArray, WordArrayTrait};
 
 /// Calculates double sha256 digest of a concatenation of two hashes.
 pub fn double_sha256_parent(a: @Digest, b: @Digest) -> Digest {
@@ -29,8 +28,10 @@ pub fn double_sha256_word_array(words: WordArray) -> Digest {
 
 #[cfg(test)]
 mod tests {
-    use crate::{hex::from_hex, hash::Digest, word_array::hex::words_from_hex};
-    use super::{double_sha256_word_array, double_sha256_parent};
+    use crate::hash::Digest;
+    use crate::hex::from_hex;
+    use crate::word_array::hex::words_from_hex;
+    use super::{double_sha256_parent, double_sha256_word_array};
 
     #[test]
     fn test_double_sha256_word_array() {

--- a/packages/utils/src/hash.cairo
+++ b/packages/utils/src/hash.cairo
@@ -1,6 +1,6 @@
 //! `Digest` struct and trait implementations.
 
-use core::fmt::{Display, Formatter, Error};
+use core::fmt::{Display, Error, Formatter};
 use core::hash::{Hash, HashStateTrait};
 use core::integer::u128_byte_reverse;
 use core::num::traits::zero::Zero;
@@ -58,7 +58,7 @@ pub impl DigestIntoByteArray of Into<Digest, ByteArray> {
         let mut bytes: ByteArray = Default::default();
         for word in self.value.span() {
             bytes.append_word((*word).into(), 4);
-        };
+        }
         bytes
     }
 }

--- a/packages/utils/src/hex.cairo
+++ b/packages/utils/src/hex.cairo
@@ -5,7 +5,7 @@ use crate::hash::Digest;
 /// Gets bytes from hex (base16).
 pub fn from_hex(hex_string: ByteArray) -> ByteArray {
     let num_characters = hex_string.len();
-    assert!(num_characters & 1 == 0, "Invalid hex string length");
+    assert!(num_characters % 2 == 0, "Invalid hex string length");
 
     let mut bytes: ByteArray = Default::default();
     let mut i = 0;
@@ -15,7 +15,7 @@ pub fn from_hex(hex_string: ByteArray) -> ByteArray {
         let lo = hex_char_to_nibble(hex_string[i + 1]);
         bytes.append_byte(hi * 16 + lo);
         i += 2;
-    };
+    }
 
     bytes
 }
@@ -32,7 +32,7 @@ pub fn to_hex(data: @ByteArray) -> ByteArray {
         result.append_byte(alphabet.at(l).unwrap());
         result.append_byte(alphabet.at(r).unwrap());
         i += 1;
-    };
+    }
 
     result
 }
@@ -52,7 +52,7 @@ pub fn hex_to_hash_rev(hex_string: ByteArray) -> Digest {
         let lo = hex_char_to_nibble(hex_string[len - i - 1]);
         unit = (unit * 256) + (hi * 16 + lo).into();
         i += 2;
-    };
+    }
     result.append(unit);
 
     Digest {
@@ -82,7 +82,7 @@ pub fn hex_char_to_nibble(hex_char: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use crate::hash::Digest;
-    use super::{from_hex, to_hex, hex_to_hash_rev};
+    use super::{from_hex, hex_to_hash_rev, to_hex};
 
     #[test]
     fn test_bytes_from_hex() {

--- a/packages/utils/src/lib.cairo
+++ b/packages/utils/src/lib.cairo
@@ -4,12 +4,9 @@ pub mod double_sha256;
 pub mod hash;
 pub mod merkle_tree;
 pub mod numeric;
+pub mod sha256;
 pub mod sort;
 pub mod word_array;
-
-
-pub mod sha256;
-// Let's use core non provable functions for now. Much faster.
 pub use core::sha256 as sha256_core;
 
 #[cfg(target: 'test')]

--- a/packages/utils/src/merkle_tree.cairo
+++ b/packages/utils/src/merkle_tree.cairo
@@ -1,6 +1,7 @@
 //! Merkle tree helpers.
 
-use super::{double_sha256::double_sha256_parent, hash::Digest};
+use super::double_sha256::double_sha256_parent;
+use super::hash::Digest;
 
 /// Calculates Merkle tree root given the array of leaves.
 pub fn merkle_root(hashes: Span<Digest>) -> Digest {
@@ -17,14 +18,14 @@ pub fn merkle_root(hashes: Span<Digest>) -> Digest {
     while let Option::Some(v) = arr.multi_pop_front::<2>() {
         let [a, b] = (*v).unbox();
         next_hashes.append(double_sha256_parent(@a, @b));
-    };
+    }
 
     if (is_odd == 1) {
         let last = *arr.pop_front().unwrap();
         next_hashes.append(double_sha256_parent(@last, @last));
     } else if (*hashes[len - 1] == *hashes[len - 2]) {
         // CVE-2012-2459 bug fix
-        panic!("unexpected node duplication in merkle tree");
+        assert(false, 'MT node duplicate CVE-2012-2459');
     }
 
     merkle_root(next_hashes.span())
@@ -32,8 +33,9 @@ pub fn merkle_root(hashes: Span<Digest>) -> Digest {
 
 #[cfg(test)]
 mod tests {
-    use crate::{hash::{Digest, U256IntoDigest}, hex::hex_to_hash_rev};
-    use super::{merkle_root};
+    use crate::hash::{Digest, U256IntoDigest};
+    use crate::hex::hex_to_hash_rev;
+    use super::merkle_root;
 
     #[test]
     #[available_gas(100000000)]

--- a/packages/utils/src/sha256.cairo
+++ b/packages/utils/src/sha256.cairo
@@ -23,7 +23,7 @@ pub fn compute_sha256_byte_array(arr: @ByteArray) -> [u32; 8] {
             + arr.at(index).unwrap().into() * 0x1000000;
         word_arr.append(word);
         index = index + 4;
-    };
+    }
     let last = match rem {
         0 => 0,
         1 => arr.at(len - 1).unwrap().into(),
@@ -47,7 +47,7 @@ pub fn compute_sha256_u32_array(
 
     while let Option::Some(chunk) = data.multi_pop_front::<16>() {
         state = sha256_inner((*chunk).unbox().span(), state);
-    };
+    }
 
     let (d0, d1, d2, d3, d4, d5, d6, d7) = state;
     [d0, d1, d2, d3, d4, d5, d6, d7]
@@ -156,7 +156,7 @@ fn sha256_inner(data: Span<u32>, h: Sha256State) -> Sha256State {
     while let Option::Some(ki) = k.pop_front() {
         let wi = w.pop_front().unwrap();
         g = compression(*wi, *ki, g);
-    };
+    }
 
     let (h0, h1, h2, h3, h4, h5, h6, h7) = h;
     let (g0, g1, g2, g3, g4, g5, g6, g7) = g;
@@ -199,7 +199,7 @@ fn create_message_schedule(data: Span<u32>) -> Span<u32> {
         let (tmp, _) = tmp.overflowing_add(*result[i - 7]);
         let (res, _) = tmp.overflowing_add(s1);
         result.append(res);
-    };
+    }
     result.span()
 }
 
@@ -351,4 +351,3 @@ mod tests {
         );
     }
 }
-

--- a/packages/utils/src/word_array.cairo
+++ b/packages/utils/src/word_array.cairo
@@ -263,7 +263,7 @@ pub impl WordArrayImpl of WordArrayTrait {
                     self.input.append(word.try_into().expect('append_bytes/1'));
                     full_words = r;
                     full_words_num_bytes -= 4;
-                };
+                }
                 self.input.append(full_words.try_into().expect('append_bytes/2'));
             }
 
@@ -314,7 +314,7 @@ pub mod hex {
     /// Gets words from hex (base16).
     pub fn words_from_hex(hex_string: ByteArray) -> WordArray {
         let num_characters = hex_string.len();
-        assert!(num_characters & 1 == 0, "Invalid hex string length");
+        assert!(num_characters % 2 == 0, "Invalid hex string length");
 
         let mut words: WordArray = Default::default();
         let mut i = 0;
@@ -324,7 +324,7 @@ pub mod hex {
             let lo = hex_char_to_nibble(hex_string[i + 1]);
             words.append_u8(hi * 16 + lo);
             i += 2;
-        };
+        }
 
         words
     }
@@ -349,7 +349,7 @@ pub mod hex {
                 result.append_byte(alphabet.at(l).expect('l'));
                 result.append_byte(alphabet.at(r).expect('r'));
             }
-        };
+        }
 
         result
     }
@@ -357,9 +357,8 @@ pub mod hex {
 
 #[cfg(test)]
 mod tests {
-    use super::WordSpanTrait;
-    use super::hex::{words_to_hex};
-    use super::{WordArray, WordArrayTrait};
+    use super::hex::words_to_hex;
+    use super::{WordArray, WordArrayTrait, WordSpanTrait};
 
     #[test]
     fn test_append_u8() {

--- a/packages/utreexo/Scarb.toml
+++ b/packages/utreexo/Scarb.toml
@@ -3,13 +3,17 @@ name = "utreexo"
 version = "0.1.0"
 edition = "2024_07"
 
+[executable]
+
+[lib]
+
 [dependencies]
+cairo_execute = "2.11.4"
 utils = { path = "../utils" }
 
 [dev-dependencies]
 cairo_test.workspace = true
 
 [scripts]
-# TODO: cairo lint
 lint = "scarb fmt"
-test = "scarb cairo-test && scarb build && ../../scripts/data/integration_tests.sh"
+test = "scarb cairo-test && scarb --profile proving build --target-kinds executable && ../../scripts/data/integration_tests.sh"

--- a/packages/utreexo/src/lib.cairo
+++ b/packages/utreexo/src/lib.cairo
@@ -5,13 +5,12 @@ pub mod stump {
 }
 pub mod vanilla {
     pub mod accumulator;
-    pub mod proof;
-    pub mod state;
     #[cfg(test)]
     mod accumulator_tests;
+    pub mod proof;
+    pub mod state;
 }
 pub mod test;
-
 use core::poseidon::hades_permutation;
 
 /// Parent hash of two Utreexo nodes.

--- a/packages/utreexo/src/stump/accumulator.cairo
+++ b/packages/utreexo/src/stump/accumulator.cairo
@@ -1,7 +1,7 @@
 use core::traits::DivRem;
-use crate::stump::state::UtreexoStumpState;
-use crate::stump::proof::{UtreexoBatchProof, UtreexoBatchProofTrait};
 use crate::parent_hash;
+use crate::stump::proof::{UtreexoBatchProof, UtreexoBatchProofTrait};
+use crate::stump::state::UtreexoStumpState;
 
 #[generate_trait]
 pub impl StumpUtreexoAccumulatorImpl of StumpUtreexoAccumulator {
@@ -35,12 +35,12 @@ pub impl StumpUtreexoAccumulatorImpl of StumpUtreexoAccumulator {
                 let (q, r) = DivRem::div_rem(next_row_len, 2);
                 next_row_len = q;
                 has_root = r;
-            };
+            }
 
             new_roots = new_roots_span.into();
             new_roots.append(Option::Some(to_add));
             leaves += 1;
-        };
+        }
 
         UtreexoStumpState { roots: new_roots.span(), num_leaves: leaves }
     }
@@ -64,7 +64,7 @@ pub impl StumpUtreexoAccumulatorImpl of StumpUtreexoAccumulator {
                     }
                 }
             }
-        };
+        }
 
         if num_matched != num_computed {
             return Result::Err(
@@ -106,7 +106,7 @@ pub impl StumpUtreexoAccumulatorImpl of StumpUtreexoAccumulator {
                 }
             }
             new_roots.append(*maybe_root);
-        };
+        }
 
         if !computed_roots.is_empty() {
             return Result::Err("Proof verification / leaf deletion failed");

--- a/packages/utreexo/src/stump/proof.cairo
+++ b/packages/utreexo/src/stump/proof.cairo
@@ -1,7 +1,8 @@
-use core::fmt::{Display, Formatter, Error};
+use core::fmt::{Display, Error, Formatter};
 use core::num::traits::Bounded;
+use utils::numeric::u64_next_power_of_two;
+use utils::sort::merged_sort;
 use crate::parent_hash;
-use utils::{numeric::u64_next_power_of_two, sort::merged_sort};
 
 /// Utreexo inclusion proof for multiple outputs.
 /// Compatible with https://github.com/utreexo/utreexo
@@ -20,10 +21,10 @@ impl UtreexoBatchProofDisplay of Display<UtreexoBatchProof> {
         let mut proofs: ByteArray = Default::default();
         for proof in *self.proof {
             proofs.append(@format!("{},", proof));
-        };
+        }
         for target in *self.targets {
             targets.append(@format!("{},", target));
-        };
+        }
         let str: ByteArray = format!(
             "UtreexoBatchProof {{ proof: [{}], leaf_index: [{}] }}", @targets, @proofs,
         );
@@ -53,7 +54,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
         let mut targets = array![];
         while let Option::Some(hash) = hashes.pop_front() {
             targets.append((*positions.pop_front().unwrap(), *hash));
-        };
+        }
         // and sort them by position to align with the proof
         targets = merged_sort(targets.span());
 
@@ -131,7 +132,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                         break;
                     }
                 }
-            };
+            }
 
             // after we processed all the targets in the current row and computed their parents,
             // we move the parents (and pending targets from the proof) to the next row and
@@ -158,7 +159,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                         merge_sorted(ref next_row_targets, ref next_row_computed)
                     }
             }
-        };
+        }
 
         // after we processed all rows of the forest, computed roots are all settled in the `roots`
         // array, which is automatically ordered, btw
@@ -192,7 +193,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
         let mut targets = array![];
         while let Option::Some(hash) = hashes.pop_front() {
             targets.append((*positions.pop_front().unwrap(), (*hash, Option::None)));
-        };
+        }
         // and sort them by position to align with the proof
         targets = merged_sort(targets.span());
 
@@ -296,7 +297,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                         break;
                     }
                 }
-            };
+            }
 
             // after we processed all the targets in the current row and computed their parents,
             // we move the parents (and pending targets from the proof) to the next row and
@@ -323,7 +324,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                         merge_sorted(ref next_row_targets, ref next_row_computed)
                     }
             }
-        };
+        }
 
         // after we processed all rows of the forest, computed roots are all settled in the `roots`
         // array, which is automatically ordered, btw
@@ -351,7 +352,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
             } else {
                 inner_result = Result::Err("Not enough targets in the proof.");
             }
-        };
+        }
 
         let mut leaf_nodes: Array<(u64, felt252)> = merged_sort(leaf_nodes.span());
 
@@ -403,7 +404,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                         );
                     break;
                 }
-            };
+            }
 
             // If row length is odd and we are at the edge this is a root.
             if pos == row_len_acc + actual_row_len - 1 && actual_row_len % 2 == 1 {
@@ -412,7 +413,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                 row_len /= 2;
                 actual_row_len /= 2;
                 continue;
-            };
+            }
 
             let parent_node = if (pos - row_len_acc) % 2 == 0 {
                 // Right sibling can be both leaf/computed or proof.
@@ -432,7 +433,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
                     if sibling_nodes.is_empty() {
                         inner_result = Result::Err("Proof is empty.");
                         break;
-                    };
+                    }
                     sibling_nodes.pop_front().unwrap()
                 };
                 parent_hash(node, right_sibling)
@@ -454,7 +455,7 @@ pub impl UtreexoBatchProofImpl of UtreexoBatchProofTrait {
             } else {
                 computed_nodes.append((parent_pos, parent_node));
             }
-        };
+        }
 
         if !sibling_nodes.is_empty() {
             return Result::Err("Proof should be empty");
@@ -481,7 +482,7 @@ fn extract_row<T, +Copy<T>, +Drop<T>>(
         }
         nodes.pop_front().unwrap();
         row.append((*pos - row_start, *value));
-    };
+    }
     row
 }
 
@@ -497,12 +498,12 @@ fn merge_sorted<T, +Drop<T>>(
                 break;
             }
             res.append(arr2.pop_front().unwrap());
-        };
+        }
         res.append((p1, v1));
-    };
+    }
     while let Option::Some(node) = arr2.pop_front() {
         res.append(node);
-    };
+    }
     res
 }
 

--- a/packages/utreexo/src/stump/state.cairo
+++ b/packages/utreexo/src/stump/state.cairo
@@ -1,4 +1,4 @@
-use core::fmt::{Display, Formatter, Error};
+use core::fmt::{Display, Error, Formatter};
 
 /// Accumulator representation of the state aka "Compact State Node".
 #[derive(Drop, Copy, PartialEq, Serde, Debug)]

--- a/packages/utreexo/src/test.cairo
+++ b/packages/utreexo/src/test.cairo
@@ -1,7 +1,6 @@
-use core::testing::get_available_gas;
-use crate::stump::state::UtreexoStumpState;
-use crate::stump::proof::UtreexoBatchProof;
 use crate::stump::accumulator::StumpUtreexoAccumulator;
+use crate::stump::proof::UtreexoBatchProof;
+use crate::stump::state::UtreexoStumpState;
 
 #[derive(Drop, Serde, Debug)]
 struct Args {
@@ -10,21 +9,16 @@ struct Args {
     leaves_to_del: Array<felt252>,
     leaves_to_add: Array<felt252>,
     expected_state: UtreexoStumpState,
-    _unused: felt252,
 }
 
-fn main(args: Array<felt252>) -> Array<felt252> {
-    let mut gas_before = get_available_gas();
-    let mut arguments = args.span();
-
-    let Args {
-        mut state, proof, leaves_to_del, leaves_to_add, expected_state, _unused: _,
-    } = Serde::deserialize(ref arguments).expect('Failed to deserialize');
+#[executable]
+fn main(args: Args) {
+    let Args { mut state, proof, leaves_to_del, leaves_to_add, expected_state } = args;
 
     match state.verify(@proof, leaves_to_del.span()) {
         Result::Ok(_) => {},
         Result::Err(err) => {
-            println!("FAIL: gas_spent={} error='{:?}'", gas_before - get_available_gas(), err);
+            println!("FAIL: error='{:?}'", err);
             panic!();
         },
     }
@@ -32,7 +26,7 @@ fn main(args: Array<felt252>) -> Array<felt252> {
     match state.verify_and_delete(@proof, leaves_to_del.span()) {
         Result::Ok(new_state) => { state = new_state; },
         Result::Err(err) => {
-            println!("FAIL: gas_spent={} error='{:?}'", gas_before - get_available_gas(), err);
+            println!("FAIL: error='{:?}'", err);
             panic!();
         },
     }
@@ -40,15 +34,9 @@ fn main(args: Array<felt252>) -> Array<felt252> {
     state = state.add(leaves_to_add.span());
 
     if state != expected_state {
-        println!(
-            "FAIL: gas_spent={} error='expected state {:?}, actual {:?}'",
-            gas_before - get_available_gas(),
-            expected_state,
-            state,
-        );
+        println!("FAIL: error='expected state {:?}, actual {:?}'", expected_state, state);
         panic!();
     }
 
-    println!("OK: gas_spent={}", gas_before - get_available_gas());
-    array![]
+    println!("OK");
 }

--- a/packages/utreexo/src/vanilla/accumulator.cairo
+++ b/packages/utreexo/src/vanilla/accumulator.cairo
@@ -23,7 +23,7 @@ pub impl VanillaUtreexoAccumulatorImpl of VanillaUtreexoAccumulator {
             } else {
                 new_roots.append(*root);
             }
-        };
+        }
 
         // Check if terminates with `Option::None`
         if (new_roots[new_roots.len() - 1].is_some()) {
@@ -59,14 +59,14 @@ pub impl VanillaUtreexoAccumulatorImpl of VanillaUtreexoAccumulator {
             }
 
             height += 1;
-        };
+        }
 
         new_roots.append(node);
         height += 1;
         while height != num_roots {
             new_roots.append(*self.roots[height]);
             height += 1;
-        };
+        }
 
         UtreexoState { roots: new_roots.span() }
     }
@@ -84,7 +84,7 @@ pub impl VanillaUtreexoAccumulatorImpl of VanillaUtreexoAccumulator {
         if let Option::Some(expected_root) = self.roots[root_index] {
             if *expected_root == proof_root {
                 return Result::Ok(());
-            };
+            }
             Result::Err(format!("Expected root {}, but computed {}", expected_root, proof_root))
         } else {
             Result::Err(format!("Target root is empty"))

--- a/packages/utreexo/src/vanilla/accumulator_tests.cairo
+++ b/packages/utreexo/src/vanilla/accumulator_tests.cairo
@@ -75,8 +75,7 @@ fn test_verify_inclusion() {
     utxo_state =
         UtreexoState {
             roots: array![
-                Option::None,
-                Option::None,
+                Option::None, Option::None,
                 Option::Some(0x73f11135a8f669c50ec8257ea06c9e231c140db996458f698b2be1f771a318f),
             ]
                 .into(),
@@ -178,8 +177,7 @@ fn test_utreexo_add() {
     utreexo_state = utreexo_state.add(outpoint);
 
     let expected: Span<Option<felt252>> = array![
-        Option::None,
-        Option::None,
+        Option::None, Option::None,
         Option::Some(0x3b3ed120874d97b712f68895b658659ee8055a82ea5bef26fa210fa956754c7),
         Option::None,
     ]
@@ -201,12 +199,10 @@ fn test_utreexo_add() {
     // Add 3 leaves
     for _ in 1..4_u8 {
         utreexo_state = utreexo_state.add(outpoint);
-    };
+    }
 
     let expected: Span<Option<felt252>> = array![
-        Option::None,
-        Option::None,
-        Option::None,
+        Option::None, Option::None, Option::None,
         Option::Some(0x7c9dbc3d6eba8cb43284ce97423a48d660612c0834baad3c2f8b423530a5619),
         Option::None,
     ]
@@ -216,7 +212,7 @@ fn test_utreexo_add() {
     // Add 22 leaves
     for _ in 1..23_u8 {
         utreexo_state = utreexo_state.add(outpoint);
-    };
+    }
 
     let expected: Span<Option<felt252>> = [
         Option::None(()),
@@ -256,10 +252,7 @@ fn test_utreexo_delete() {
         .add(0xFFFFFFFFFFFFFFFFFFFFFFF1);
 
     let expected: Span<Option<felt252>> = array![
-        Option::None,
-        Option::None,
-        Option::None,
-        Option::None,
+        Option::None, Option::None, Option::None, Option::None,
         Option::Some(0x1818a64c0ecbcb9fec43227f7b137c9567b936cabbc378711c52c2bb5b4b53a),
         Option::None,
     ]
@@ -285,8 +278,7 @@ fn test_utreexo_delete() {
         Option::Some(0x181a554869978703143b97d281460c38e30fe6ba52eb0a03641e446beb0f610),
         Option::Some(0x1f35ec8aaadbda4f4f28d098ad0d073f8acbba791a8ef10d6b798c5b6150ebe),
         Option::Some(0x600961c4f15bc633f584abbd7f10c77a053552ef53baebfedc689c223c2a314),
-        Option::None,
-        Option::None,
+        Option::None, Option::None,
     ]
         .span();
 

--- a/packages/utreexo/src/vanilla/proof.cairo
+++ b/packages/utreexo/src/vanilla/proof.cairo
@@ -1,5 +1,5 @@
+use core::fmt::{Display, Error, Formatter};
 use crate::parent_hash;
-use core::fmt::{Display, Formatter, Error};
 
 /// Utreexo inclusion proof for a single transaction output.
 #[derive(Drop, Copy, Serde)]
@@ -17,7 +17,7 @@ impl UtreexoProofDisplay of Display<UtreexoProof> {
         let mut proofs: ByteArray = Default::default();
         for proof in *self.proof {
             proofs.append(@format!("{},", proof));
-        };
+        }
         let str: ByteArray = format!(
             "UtreexoProof {{ proof: {}, leaf_index: {} }}", *self.leaf_index, @proofs,
         );
@@ -46,7 +46,7 @@ pub impl UtreexoProofImpl of UtreexoProofTrait {
             };
             curr_node = parent_hash(left, right);
             node_index = next_node_index;
-        };
+        }
         // Return the computed root (or the node itself if the proof is empty).
         curr_node
     }

--- a/packages/utreexo/src/vanilla/state.cairo
+++ b/packages/utreexo/src/vanilla/state.cairo
@@ -1,4 +1,4 @@
-use core::fmt::{Display, Formatter, Error};
+use core::fmt::{Display, Error, Formatter};
 use crate::vanilla::accumulator::VanillaUtreexoAccumulator;
 use crate::vanilla::proof::UtreexoProof;
 
@@ -49,12 +49,12 @@ pub impl UtreexoStateImpl of UtreexoStateTrait {
                 inner_result = Result::Err(format!("Missing proof for leaf {}", hash));
                 break;
             }
-        };
+        }
         inner_result?;
 
         for hash in hashes_to_add {
             state = state.add(*hash);
-        };
+        }
 
         Result::Ok(state)
     }

--- a/scripts/data/client.py
+++ b/scripts/data/client.py
@@ -143,6 +143,8 @@ def process_batch(job):
     stdout, stderr, returncode = run(
         [
             "scarb",
+            "--profile",
+            "proving",
             "execute",
             "--no-build",
             "--package",
@@ -388,10 +390,6 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--maxweight", type=int, default=MAX_WEIGHT_LIMIT, help="Max weight limit"
-    )
-
-    parser.add_argument(
-        "--execute-scripts", action="store_true", help="Execute scripts"
     )
 
     parser.add_argument("--verbose", action="store_true", help="Verbose")

--- a/scripts/data/client.sh
+++ b/scripts/data/client.sh
@@ -29,7 +29,7 @@ run_client() {
 
   echo -n "Running $mode client on blocks $first - $second "
   python ../../scripts/data/format_args.py $batch_file > $arguments_file
-  output=$(scarb execute --no-build --package client --arguments-file $arguments_file)
+  output=$(scarb --profile proving execute --no-build --package client --arguments-file $arguments_file)
   if [[ $? -ne 0 || "$output" == *"FAIL"* || "$output" == *error* || "$output" == *panicked* ]]; then
     echo "fail"
     echo $output

--- a/scripts/data/client.sh
+++ b/scripts/data/client.sh
@@ -29,7 +29,7 @@ run_client() {
 
   echo -n "Running $mode client on blocks $first - $second "
   python ../../scripts/data/format_args.py $batch_file > $arguments_file
-  output=$(scarb cairo-run --no-build --package client --function main --arguments-file $arguments_file)
+  output=$(scarb execute --no-build --package client --arguments-file $arguments_file)
   if [[ $? -ne 0 || "$output" == *"FAIL"* || "$output" == *error* || "$output" == *panicked* ]]; then
     echo "fail"
     echo $output

--- a/scripts/data/format_args.py
+++ b/scripts/data/format_args.py
@@ -92,47 +92,18 @@ def flatten_tuples(src) -> list:
     return res
 
 
-def format_cairo1_run(args: list) -> str:
-    """Formats arguments for usage with cairo1-run.
-    Example: [0, 1, [2, 3, 4]] -> "[0 1 [2 3 4]]"
-
-    :param args: Python object containing already processed arguments.
-    :return: Returns string with removed commas.
-    """
-
-    def format_item(item):
-        if isinstance(item, list):
-            arr = " ".join(map(format_item, item))
-            return f"[{arr}]"
-        else:
-            return str(item)
-
-    return format_item(args)
-
-
-def format_args(input_file, execute_script, cairo1_run):
+def format_args(input_file):
     """Reads arguments from JSON file and prints formatted result.
     Expects a single CLI argument containing file path.
     Output is compatible with the Scarb runner arguments format.
     """
     args = json.loads(Path(input_file).read_text())
     res = flatten_tuples(serialize(args))
-    res.append(1 if execute_script else 0)
-    if cairo1_run:
-        return format_cairo1_run(res)
-    else:
-        return [res]
+    return json.dumps(list(map(hex, res)))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Prepare arguments for Scarb runner.")
-
-    parser.add_argument(
-        "--execute_script",
-        dest="execute_script",
-        action="store_true",
-        help="Execute script",
-    )
 
     parser.add_argument(
         "--input_file",
@@ -142,12 +113,6 @@ if __name__ == "__main__":
         help="Input file with arguments in JSON format",
     )
 
-    parser.add_argument(
-        "--cairo1_run",
-        action="store_true",
-        help="Whether to format args for cairo1-run or not",
-    )
-
     args = parser.parse_args()
 
-    print(format_args(args.input_file, args.execute_script, args.cairo1_run))
+    print(format_args(args.input_file))

--- a/scripts/data/integration_tests.sh
+++ b/scripts/data/integration_tests.sh
@@ -10,20 +10,17 @@ num_ignored=0
 failures=()
 test_files=()
 nocapture=0
-execute_scripts=0
 forceall=0
-fullonly=0
+lightonly=0
 
 # Process arguments
 for arg in "$@"; do
   if [[ "$arg" == "--nocapture" ]]; then
     nocapture=1
-  elif [[ "$arg" == "--fullonly" ]]; then
-    fullonly=1
+  elif [[ "$arg" == "--lightonly" ]]; then
+    lightonly=1
   elif [[ "$arg" == "--forceall" ]]; then
     forceall=1
-  elif [[ "$arg" == "--execute-scripts" ]]; then
-    execute_scripts=1
   else
     test_files+=("$arg")  # Add only non-flag arguments as test files
   fi
@@ -42,17 +39,13 @@ fi
 ignored="${ignored_files[@]}"
 
 # If no test files are explicitly specified, default to tests/data/*
-if [[ $fullonly -eq 1 && ${#test_files[@]} -eq 0 ]]; then
-  test_files=("tests/data"/full*.json)
+if [[ $lightonly -eq 1 && ${#test_files[@]} -eq 0 ]]; then
+  test_files=("tests/data"/light*.json)
 elif [[ ${#test_files[@]} -eq 0 ]]; then
   test_files=("tests/data"/*.json)
 fi
 
-if [[ $execute_scripts -eq 1 ]]; then
-    echo "running integration tests (with scripts) ..."
-else
-    echo "running integration tests ..."
-fi
+echo "running integration tests ..."
 
 for test_file in "${test_files[@]}"; do
     if [ -f "$test_file" ]; then
@@ -62,8 +55,8 @@ for test_file in "${test_files[@]}"; do
             num_ignored=$((num_ignored + 1))
         else
             arguments_file="$(dirname "$test_file")/.arguments-$(basename "$test_file")"
-            python ../../scripts/data/format_args.py --input_file ${test_file} $([[ $execute_scripts -eq 1 ]] && echo "--execute_script") > $arguments_file
-            output=$(scarb cairo-run --no-build --function main --print-resource-usage --arguments-file $arguments_file)
+            python ../../scripts/data/format_args.py --input_file ${test_file} > $arguments_file
+            output=$(scarb execute --no-build --print-resource-usage --arguments-file $arguments_file)
             steps=$(echo $output | grep -o 'steps: [0-9]*' | sed 's/steps: //')
 
             if [[ "$nocapture" -eq 1 ]]; then

--- a/scripts/data/integration_tests.sh
+++ b/scripts/data/integration_tests.sh
@@ -56,7 +56,7 @@ for test_file in "${test_files[@]}"; do
         else
             arguments_file="$(dirname "$test_file")/.arguments-$(basename "$test_file")"
             python ../../scripts/data/format_args.py --input_file ${test_file} > $arguments_file
-            output=$(scarb execute --no-build --print-resource-usage --arguments-file $arguments_file)
+            output=$(scarb --profile proving execute --no-build --print-resource-usage --arguments-file $arguments_file)
             steps=$(echo $output | grep -o 'steps: [0-9]*' | sed 's/steps: //')
 
             if [[ "$nocapture" -eq 1 ]]; then

--- a/scripts/data/integration_tests.sh
+++ b/scripts/data/integration_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SCARB=scarb
+
 GREEN='\033[0;32m'
 RED='\033[1;31m'
 RESET='\033[0m' # No Color
@@ -56,7 +58,9 @@ for test_file in "${test_files[@]}"; do
         else
             arguments_file="$(dirname "$test_file")/.arguments-$(basename "$test_file")"
             python ../../scripts/data/format_args.py --input_file ${test_file} > $arguments_file
-            output=$(scarb --profile proving execute --no-build --print-resource-usage --arguments-file $arguments_file)
+            output=$($SCARB --profile proving execute --no-build --print-resource-usage --arguments-file $arguments_file)
+            # See https://github.com/software-mansion/scarb/pull/2276
+            rm -rf ../../target/execute
             steps=$(echo $output | grep -o 'steps: [0-9]*' | sed 's/steps: //')
 
             if [[ "$nocapture" -eq 1 ]]; then


### PR DESCRIPTION
- Shinigami and core::sha256 temporarily disabled while we investigate why compiler fails to build with "allow-syscalls" flag on
- Until then only light test cases are run, because full blocks take too much steps with naive sha256
- I removed the execute script flag to simplify the flow: I propose to have a (semi)manual feature switch in the consensus package instead, until it's finally implemented in Scarb
